### PR TITLE
Adds support for Laravel 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ matrix:
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.1
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
     - php: 7.2
       env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
     - php: 7.2
-      env: COVERAGE=1 LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+    - php: 7.2
+      env: COVERAGE=1 LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
   fast_finish: true
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Support for Laravel 5.7 ([#13](https://github.com/honeybadger-io/honeybadger-laravel/pull/13))
+
 ### Changed
 * Updated the Travis CI config ([#14](https://github.com/honeybadger-io/honeybadger-laravel/pull/14))
 * Updated [honeybadger-io/honeybadger-php](https://github.com/honeybadger-io/honeybadger-php) ([#14](https://github.com/honeybadger-io/honeybadger-laravel/pull/14))

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "friendsofphp/php-cs-fixer": "^2.10",
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^3.5|^3.6",
+        "orchestra/testbench": "^3.5|^3.6|^3.7",
         "phpunit/phpunit": "^6.0|^7.0"
     },
     "autoload": {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

Held for #14.

## Description
Adds support for Laravel 5.7

## Related PRs
n/a

## Todos
- [x] Tests
- n/a Documentation
- [x] Changelog Entry (unreleased)
- [x] Update travis support for 5.7

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
