### PR TITLE
Update Travis and honeybadger-php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
   - vendor/bin/phpunit
 
 after_success:
-  - if [[ $COVERAGE = 1 ]]; then ./bin/codeclimate $TRAVIS_TEST_RESULT; fi
+  - if [[ $COVERAGE = 1 ]]; then ./bin/codeclimate report $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,38 @@
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 language: php
 
-php:
-  - 7.1
-  - 7.2
-
 env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
-    - COMPOSER_FLAGS=""
+  global:
+    - COVERAGE=0
+
+matrix:
+  include:
+    - php: 7.1
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.2
+      env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
+    - php: 7.2
+      env: COVERAGE=1 LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+  fast_finish: true
 
 before_script:
+    - composer config discard-changes true
+    - if [[ $COVERAGE = '1' ]]; then ./bin/codeclimate setup; fi
+
+before_install:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+
+install:
+  - travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 script:
   - vendor/bin/phpunit
 
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+after_success:
+  - if [[ $COVERAGE = 1 ]]; then ./bin/codeclimate $TRAVIS_TEST_RESULT; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-* Updated the Travis CI config
-* Updated [honeybadger-io/honeybadger-php](https://github.com/honeybadger-io/honeybadger-php)
+* Updated the Travis CI config ([#14](https://github.com/honeybadger-io/honeybadger-laravel/pull/14))
+* Updated [honeybadger-io/honeybadger-php](https://github.com/honeybadger-io/honeybadger-php) ([#14](https://github.com/honeybadger-io/honeybadger-laravel/pull/14))
 
 ## [1.2.0] - 2018-08-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Updated the Travis CI config
+* Updated [honeybadger-io/honeybadger-php](https://github.com/honeybadger-io/honeybadger-php)
 
 ## [1.2.0] - 2018-08-17
 ### Changed

--- a/bin/codeclimate
+++ b/bin/codeclimate
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $1 = 'setup' ]]; then
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+    ./cc-test-reporter before-build
+fi
+
+if [[ $1 = 'report' ]]; then
+    ./cc-test-reporter after-build --exit-code $2
+fi

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1|^7.2",
-        "honeybadger-io/honeybadger-php": "^1.1",
+        "honeybadger-io/honeybadger-php": "^1.2",
         "illuminate/console": "^5.5|^5.6",
         "illuminate/support": "^5.5|^5.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.1",
         "orchestra/testbench": "^3.5|^3.6",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

Held for https://github.com/honeybadger-io/honeybadger-php/pull/65

## Description
Update the Travis configuration so there is better coverage across Laravel versions. This is expected to fail for Laravel 5.5 versions until the related PR on `honeybadger-php` is tagged and released.

## Related PRs
List related PRs against other branches:

* https://github.com/honeybadger-io/honeybadger-php/pull/65

## Todos
- n/a Tests
- n/a Documentation
- [x] Changelog Entry (unreleased)
- [x] Update `honeybadger-io/honeybadger-php` version

## Steps to Test or Reproduce
Review CI Process