### PR TITLE
Remove vendor/bin path from Composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,10 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "phpunit",
         "test-coverage": "phpunit --coverage-html coverage",
-        "styles:lint": "vendor/bin/php-cs-fixer fix --dry-run --diff",
-        "styles:fix": "vendor/bin/php-cs-fixer fix"
+        "styles:lint": "php-cs-fixer fix --dry-run --diff",
+        "styles:fix": "php-cs-fixer fix"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
As discussed in sixlive/hb-laravel#1, the `vendor/bin/` folder will automatically be pushed to the top of the `$PATH` environment variable when running Composer scripts, so it'll automatically check in that folder. 

See the note on [this page](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) of the Composer documentation.