### PR TITLE
Add php73 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
     - php: 7.2
       env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.2
+      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
+    - php: 7.3
+      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+    - php: 7.3
       env: COVERAGE=1 LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
   fast_finish: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* PHP 7.3 to Travis
+
 ### Removed
 * php-cs-fixer dev dependency
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|7.2",
+        "php": "^7.1",
         "honeybadger-io/honeybadger-php": "^1.2",
         "sixlive/dotenv-editor": "^1.1",
         "illuminate/console": "^5.5",


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Adds PHP 7.3 to the Travis build matrix and removes unnecessary over specification of php versions in the composer manifest.

## Related PRs
List related PRs against other branches:

* https://github.com/honeybadger-io/honeybadger-php/pull/68

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Watch CI process of PR