### PR TITLE
Add deploy command

### DIFF
--- a/src/Commands/HoneybadgerDeployCommand.php
+++ b/src/Commands/HoneybadgerDeployCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Honeybadger\HoneybadgerLaravel\Commands;
+
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class HoneybadgerDeployCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'honeybadger:deploy {--apiKey=} {--environment=} {--revision=} {--repository=} {--username=}';
+
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send deployment to Honeybadger';
+
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    public function __construct(Client $client)
+    {
+        parent::__construct();
+
+        $this->client = $client;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $response = $this->client->post(
+            'https://api.honeybadger.io/v1/deploys',
+            [
+                'form_params' => $this->resolveParams(),
+            ]
+        );
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        if ($response->getStatusCode() !== 200 && $body['status'] === 'OK') {
+            throw new \Exceptions("Sending the deployment to Honeybadger faild. Status Code {$response->getStatusCode()}");
+        }
+    }
+
+    private function resolveParams() : array
+    {
+        return array_merge(
+            $this->resolveConfigValues(),
+            $this->resolveOptions()
+        );
+    }
+
+    private function resolveConfigValues() : array
+    {
+        $config = Config::get('honeybadger');
+
+        return [
+           'api_key'  => $config['api_key'],
+           'revision' => $config['version'] ?? $this->gitHash(),
+           'environment' => $config['environment_name'],
+        ];
+    }
+
+    private function resolveOptions() : array
+    {
+        return array_filter([
+            'api_key' => $this->option('apiKey'),
+            'environment' => $this->option('environment'),
+            'revision' => $this->option('revision'),
+            'repository' => $this->option('repository') ?? $this->gitRemote(),
+            'local_username' => $this->option('username') ?? get_current_user(),
+        ]);
+    }
+
+    private function gitHash() : string
+    {
+        return trim(exec('git log --pretty="%h" -n1 HEAD'));
+    }
+
+    private function gitRemote() : string
+    {
+        return trim(exec('git config --get remote.origin.url'));
+    }
+}

--- a/src/Commands/HoneybadgerDeployCommand.php
+++ b/src/Commands/HoneybadgerDeployCommand.php
@@ -53,8 +53,11 @@ class HoneybadgerDeployCommand extends Command
 
         $body = json_decode((string) $response->getBody(), true);
 
-        if ($response->getStatusCode() !== 200 && $body['status'] === 'OK') {
-            throw new \Exceptions("Sending the deployment to Honeybadger faild. Status Code {$response->getStatusCode()}");
+        if ($response->getStatusCode() !== 200 || $body['status'] !== 'OK') {
+            throw new \Exception(vsprintf('Sending the deployment to Honeybadger failed. Status code %s. Response %s.', [
+                $response->getStatusCode(),
+                (string) $response->getBody(),
+            ]));
         }
     }
 

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace Honeybadger\HoneybadgerLaravel;
 
+use GuzzleHttp\Client;
 use Honeybadger\Honeybadger;
 use Honeybadger\Contracts\Reporter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Console\Scheduling\Event;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerTestCommand;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerDeployCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckinCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerInstallCommand;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer as InstallerContract;
@@ -48,6 +50,14 @@ class HoneybadgerServiceProvider extends ServiceProvider
         $this->app->singleton('honeybadger.isLumen', function () {
             return preg_match('/lumen/i', $this->app->version());
         });
+
+        $this->app->when(HoneybadgerDeployCommand::class)
+            ->needs(Client::class)
+            ->give(function () {
+                return new Client([
+                    'http_errors' => false,
+                ]);
+            });
     }
 
     /**
@@ -59,6 +69,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
             'command.honeybadger:test',
             'command.honeybadger:checkin',
             'command.honeybadger:install',
+            'command.honeybadger:deploy',
         ]);
     }
 
@@ -80,6 +91,11 @@ class HoneybadgerServiceProvider extends ServiceProvider
         $this->app->bind(
             'command.honeybadger:install',
             HoneybadgerInstallCommand::class
+        );
+
+        $this->app->bind(
+            'command.honeybadger:deploy',
+            HoneybadgerDeployCommand::class
         );
     }
 

--- a/src/Middleware/UserContext.php
+++ b/src/Middleware/UserContext.php
@@ -32,7 +32,7 @@ class UserContext
         if (app()->bound('honeybadger') && $request->user()) {
             $this->honeybadger->context(
                 'user_id',
-                 $request->user()->getAuthIdentifier()
+                $request->user()->getAuthIdentifier()
             );
         }
 

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -26,7 +26,7 @@ class HoneybadgerDeployCommandTest extends TestCase
                 $this->url = $url;
                 $this->options = $options;
 
-                return $this->response ?? new Response(200, [], json_encode(['status' => 'OK']));
+                return $this->response ?? new Response(201, [], json_encode(['status' => 'OK']));
             }
         };
 
@@ -52,10 +52,12 @@ class HoneybadgerDeployCommandTest extends TestCase
         $this->assertEquals([
             'form_params' => [
                 'api_key' => 'secret1234',
-                'environment' => 'production',
-                'revision' => '1.1.0',
-                'repository' => trim(exec('git config --get remote.origin.url')),
-                'local_username' => get_current_user(),
+                'deploy' => [
+                    'environment' => 'production',
+                    'revision' => '1.1.0',
+                    'repository' => trim(exec('git config --get remote.origin.url')),
+                    'local_username' => get_current_user(),
+                ],
             ],
         ], $this->client->options);
     }
@@ -71,7 +73,7 @@ class HoneybadgerDeployCommandTest extends TestCase
         $this->artisan('honeybadger:deploy');
 
         $this->assertEquals(
-            $this->client->options['form_params']['revision'],
+            $this->client->options['form_params']['deploy']['revision'],
             trim(exec('git log --pretty="%h" -n1 HEAD'))
         );
     }
@@ -96,10 +98,12 @@ class HoneybadgerDeployCommandTest extends TestCase
         $this->assertEquals([
             'form_params' => [
                 'api_key' => 'supersecret',
-                'environment' => 'staging',
-                'revision' => '2.0',
-                'repository' => 'https://github.com/honeybadger-io/honeybadger-laravel',
-                'local_username' => 'systemuser',
+                'deploy' => [
+                    'environment' => 'staging',
+                    'revision' => '2.0',
+                    'repository' => 'https://github.com/honeybadger-io/honeybadger-laravel',
+                    'local_username' => 'systemuser',
+                ],
             ],
         ], $this->client->options);
     }

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Honeybadger\Tests\Commands;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Honeybadger\Tests\TestCase;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerDeployCommand;
+
+class HoneybadgerDeployCommandTest extends TestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $client = new class extends Client {
+            protected $response = null;
+
+            public function setResponse($response)
+            {
+                $this->response = $response;
+            }
+
+            public function post($url, $options = [])
+            {
+                $this->url = $url;
+                $this->options = $options;
+
+                return $this->response ?? new Response(200);
+            }
+        };
+
+        $this->client = $client;
+
+        $this->app->when(HoneybadgerDeployCommand::class)
+            ->needs(Client::class)
+            ->give(function () use ($client) {
+                return $client;
+            });
+    }
+
+    /** @test */
+    public function default_params_resolve()
+    {
+        $this->app['config']->set('honeybadger', [
+            'api_key' => 'secret1234',
+            'version' => '1.1.0',
+            'environment_name' => 'production',
+        ]);
+
+        $this->artisan('honeybadger:deploy');
+        $this->assertEquals([
+            'form_params' => [
+                'api_key' => 'secret1234',
+                'environment' => 'production',
+                'revision' => '1.1.0',
+                'repository' => trim(exec('git config --get remote.origin.url')),
+                'local_username' => get_current_user(),
+            ],
+        ], $this->client->options);
+    }
+
+    /** @test */
+    public function revision_falls_back_to_git_hash()
+    {
+        $this->app['config']->set('honeybadger', array_merge(
+            $this->app['config']->get('honeybadger'),
+            ['version' => null]
+        ));
+
+        $this->artisan('honeybadger:deploy');
+
+        $this->assertEquals(
+            $this->client->options['form_params']['revision'],
+            trim(exec('git log --pretty="%h" -n1 HEAD'))
+        );
+    }
+
+    /** @test */
+    public function params_from_options_override_defaults()
+    {
+        $this->app['config']->set('honeybadger', [
+            'api_key' => 'secret1234',
+            'version' => '1.1.0',
+            'environment_name' => 'production',
+        ]);
+
+        $this->artisan('honeybadger:deploy', [
+            '--apiKey' => 'supersecret',
+            '--environment' => 'staging',
+            '--revision' => '2.0',
+            '--repository' => 'https://github.com/honeybadger-io/honeybadger-laravel',
+            '--username' => 'systemuser',
+        ]);
+
+        $this->assertEquals([
+            'form_params' => [
+                'api_key' => 'supersecret',
+                'environment' => 'staging',
+                'revision' => '2.0',
+                'repository' => 'https://github.com/honeybadger-io/honeybadger-laravel',
+                'local_username' => 'systemuser',
+            ],
+        ], $this->client->options);
+    }
+}

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -26,7 +26,7 @@ class HoneybadgerDeployCommandTest extends TestCase
                 $this->url = $url;
                 $this->options = $options;
 
-                return $this->response ?? new Response(200);
+                return $this->response ?? new Response(200, [], json_encode(['status' => 'OK']));
             }
         };
 
@@ -102,5 +102,29 @@ class HoneybadgerDeployCommandTest extends TestCase
                 'local_username' => 'systemuser',
             ],
         ], $this->client->options);
+    }
+
+    /** @test */
+    public function invalid_status_codes_trigger_an_exception()
+    {
+        $this->client->setResponse(new Response(500));
+
+        try {
+            $this->artisan('honeybadger:deploy');
+        } catch (\Exception $e) {
+            $this->assertRegexp('/500/', $e->getMessage());
+        }
+    }
+
+    /** @test */
+    public function invalid_response_trigger_an_exception()
+    {
+        $this->client->setResponse(new Response(200, [], json_encode(['status' => 'BAD'])));
+
+        try {
+            $this->artisan('honeybadger:deploy');
+        } catch (\Exception $e) {
+            $this->assertRegexp('/{"status":"BAD"}/', $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**WIP**

## Description
Adds a deploy command `honeybadger:deploy`. Unless the options are passed to the command it will resolve params from the Laravel/Honeybadger config ([config/honeybadger.php](https://github.com/honeybadger-io/honeybadger-laravel/blob/master/config/honeybadger.php)) and system calls to get the git hash and local username. The command will merge options together if mixed options are passed.

**Options:**
`honeybadger:deploy --apiKey="" --environment="" --revision="" --repository= --username=""`

Resolves #25

***I STILL NEED TO DO FINAL TESTING TO HONEYADGER IN PRODUCTION***

## Related PRs
n/a

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
