### PR TITLE
Adds support for `report_data`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "honeybadger-io/honeybadger-php": "^1.2",
+        "honeybadger-io/honeybadger-php": "^1.3",
         "sixlive/dotenv-editor": "^1.1",
         "illuminate/console": "^5.5",
         "illuminate/support": "^5.5"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "honeybadger-io/honeybadger-php": "^1.3",
+        "honeybadger-io/honeybadger-php": "^1.5",
         "sixlive/dotenv-editor": "^1.1",
         "illuminate/console": "^5.5",
         "illuminate/support": "^5.5"

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -23,4 +23,5 @@ return [
         'proxy' => [],
     ],
     'excluded_exceptions' => [],
+    'report_data' => env('APP_ENV') !== 'testing',
 ];

--- a/src/Middleware/UserContext.php
+++ b/src/Middleware/UserContext.php
@@ -32,7 +32,7 @@ class UserContext
         if (app()->bound('honeybadger') && $request->user()) {
             $this->honeybadger->context(
                 'user_id',
-                 $request->user()->getAuthIdentifier()
+                $request->user()->getAuthIdentifier()
             );
         }
 


### PR DESCRIPTION
## Description
Add the new `report_data` option to the default config initially excluding the `testing` env which is set for phpunit by default with Laravel.

## Notes
Requires https://github.com/honeybadger-io/honeybadger-php/pull/82 to be released, updated composer requirements for the perspective version.