### PR TITLE
Adds controller and action to the context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Controller action and component to middleware ([#31](https://github.com/honeybadger-io/honeybadger-laravel/pull/31))
 
 ## [1.6.0] - 2019-06-27
 ### Added

--- a/src/Middleware/HoneybadgerContext.php
+++ b/src/Middleware/HoneybadgerContext.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Honeybadger\HoneybadgerLaravel\Middleware;
+
+use Closure;
+use Honeybadger\Contracts\Reporter;
+use Illuminate\Support\Facades\Route;
+
+class HoneybadgerContext
+{
+    /**
+     * @var \Honeybadger\Honeybadger;
+     */
+    protected $honeybadger;
+
+    /**
+     * @param  \Honeybadger\Contracts\Reporter  $honeybadger
+     */
+    public function __construct(Reporter $honeybadger)
+    {
+        $this->honeybadger = $honeybadger;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (app()->bound('honeybadger')) {
+            $this->setUserContext($request);
+            $this->setRouteActionContext();
+        }
+
+        return $next($request);
+    }
+
+    private function setRouteActionContext()
+    {
+        if (Route::getCurrentRoute()) {
+            $routeAction = explode('@', Route::getCurrentRoute()->getActionName());
+
+            $this->honeybadger->context(
+                'component',
+                $routeAction[0] ?? null
+            );
+
+            $this->honeybadger->context(
+                'action',
+                $routeAction[1] ?? null
+            );
+        }
+    }
+
+    private function setUserContext($request)
+    {
+        if ($request->user()) {
+            $this->honeybadger->context(
+                'user_id',
+                $request->user()->getAuthIdentifier()
+            );
+        }
+    }
+}

--- a/src/Middleware/HoneybadgerContext.php
+++ b/src/Middleware/HoneybadgerContext.php
@@ -43,15 +43,8 @@ class HoneybadgerContext
         if (Route::getCurrentRoute()) {
             $routeAction = explode('@', Route::getCurrentRoute()->getActionName());
 
-            $this->honeybadger->context(
-                'component',
-                $routeAction[0] ?? null
-            );
-
-            $this->honeybadger->context(
-                'action',
-                $routeAction[1] ?? null
-            );
+            $this->honeybadger->setComponent($routeAction[0] ?? null);
+            $this->honeybadger->setAction($routeAction[1] ?? null);
         }
     }
 

--- a/src/Middleware/UserContext.php
+++ b/src/Middleware/UserContext.php
@@ -2,40 +2,7 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Middleware;
 
-use Closure;
-use Honeybadger\Contracts\Reporter;
-
-class UserContext
+class UserContext extends HoneybadgerContext
 {
-    /**
-     * @var \Honeybadger\Honeybadger;
-     */
-    protected $honeybadger;
-
-    /**
-     * @param  \Honeybadger\Contracts\Reporter  $honeybadger
-     */
-    public function __construct(Reporter $honeybadger)
-    {
-        $this->honeybadger = $honeybadger;
-    }
-
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
-     */
-    public function handle($request, Closure $next)
-    {
-        if (app()->bound('honeybadger') && $request->user()) {
-            $this->honeybadger->context(
-                'user_id',
-                $request->user()->getAuthIdentifier()
-            );
-        }
-
-        return $next($request);
-    }
+    // Backwards Compatibility
 }


### PR DESCRIPTION
## Description
Adds a new middleware which should be referenced in the documentation `HoneybadgerContext`. I updated the current `UserContext` middleware to extend this prevent a breaking change. This will set and send the controller and action if available.

<img width="1132" alt="Screen Shot 2019-07-20 at 1 43 10 PM" src="https://user-images.githubusercontent.com/5108034/61582092-5bc6ad00-aaf4-11e9-815b-7707cfdcc31f.png">
<img width="1167" alt="Screen Shot 2019-07-20 at 1 42 58 PM" src="https://user-images.githubusercontent.com/5108034/61582094-5d907080-aaf4-11e9-9793-57cffb8faf62.png">


## Related PRs
**DEPENDS ON**: https://github.com/honeybadger-io/honeybadger-php/pull/87

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
