### PR TITLE
Add a check to ensure component and action are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Request action and component
 
 ## [1.7.0] - 2019-09-04
 ### Added

--- a/src/Middleware/HoneybadgerContext.php
+++ b/src/Middleware/HoneybadgerContext.php
@@ -43,8 +43,10 @@ class HoneybadgerContext
         if (Route::getCurrentRoute()) {
             $routeAction = explode('@', Route::getCurrentRoute()->getActionName());
 
-            $this->honeybadger->setComponent($routeAction[0] ?? null);
-            $this->honeybadger->setAction($routeAction[1] ?? null);
+            if ($routeAction[0] && $routeAction[1]) {
+                $this->honeybadger->setComponent($routeAction[0] ?? '');
+                $this->honeybadger->setAction($routeAction[1] ?? '');
+            }
         }
     }
 

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Honeybadger\Tests\Fixtures;
+
+class TestController
+{
+    public function index()
+    {
+        return response()->json([]);
+    }
+}

--- a/tests/UserContextMiddlewareTest.php
+++ b/tests/UserContextMiddlewareTest.php
@@ -2,9 +2,12 @@
 
 namespace Honeybadger\Tests;
 
+use Honeybadger\Honeybadger;
 use Illuminate\Http\Request;
 use Honeybadger\Contracts\Reporter;
+use Illuminate\Support\Facades\Route;
 use Honeybadger\HoneybadgerLaravel\Middleware\UserContext;
+use Honeybadger\HoneybadgerLaravel\Middleware\HoneybadgerContext;
 
 class UserContextMiddlewareTest extends TestCase
 {
@@ -33,5 +36,49 @@ class UserContextMiddlewareTest extends TestCase
         $middleware->handle($request, function () {
             //
         });
+    }
+
+    /** @test */
+    public function it_sets_action_and_context()
+    {
+        $honeybadger = $this->createMock(Honeybadger::class);
+
+        $honeybadger->expects($this->once())
+            ->method('setComponent')
+            ->with('Honeybadger\Tests\Fixtures\TestController');
+
+        $honeybadger->expects($this->once())
+            ->method('setAction')
+            ->with('index');
+
+        $this->app[Reporter::class] = $honeybadger;
+
+        Route::middleware(HoneybadgerContext::class)
+            ->namespace('Honeybadger\Tests\Fixtures')
+            ->group(function () {
+                Route::get('test', 'TestController@index');
+            });
+
+        $this->get('test');
+    }
+
+    /** @test */
+    public function it_does_not_set_action_and_context()
+    {
+        $honeybadger = $this->createMock(Honeybadger::class);
+
+        $honeybadger->expects($this->never())
+            ->method('setComponent');
+
+        $honeybadger->expects($this->never())
+            ->method('setAction');
+
+        $this->app[Reporter::class] = $honeybadger;
+
+        Route::get('test', function () {
+            return response(null, 200);
+        })->middleware(HoneybadgerContext::class);
+
+        $this->get('test');
     }
 }


### PR DESCRIPTION
## Description
Fixes an issue introduced with 1.7.0 with request component and action. This ensures that they are present before attempting to set them. Defaults to string if it slips through per the contract.

Resolves https://github.com/honeybadger-io/honeybadger-laravel/issues/34

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
