### PR TITLE
Fix component without action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error whent here is a component and not an action
 
 ## [1.7.1] - 2019-09-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.1] - 2019-09-05
 ### Fixed
-* Request action and component
+* Request action and component ([#35](https://github.com/honeybadger-io/honeybadger-laravel/pull/35))
 
 ## [1.7.0] - 2019-09-04
 ### Added

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -7,7 +7,7 @@ use Honeybadger\Contracts\Reporter;
 
 class HoneybadgerLaravel
 {
-    const VERSION = '1.7.0';
+    const VERSION = '1.7.1';
 
     /**
      * Honeybadger factory.

--- a/src/Middleware/HoneybadgerContext.php
+++ b/src/Middleware/HoneybadgerContext.php
@@ -43,8 +43,11 @@ class HoneybadgerContext
         if (Route::getCurrentRoute()) {
             $routeAction = explode('@', Route::getCurrentRoute()->getActionName());
 
-            if ($routeAction[0] && $routeAction[1]) {
+            if (! empty($routeAction[0])) {
                 $this->honeybadger->setComponent($routeAction[0] ?? '');
+            }
+
+            if (! empty($routeAction[1])) {
                 $this->honeybadger->setAction($routeAction[1] ?? '');
             }
         }

--- a/tests/Fixtures/TestInvokableController.php
+++ b/tests/Fixtures/TestInvokableController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Honeybadger\Tests\Fixtures;
+
+class TestInvokableController
+{
+    public function __invoke()
+    {
+        return response()->json([]);
+    }
+}

--- a/tests/UserContextMiddlewareTest.php
+++ b/tests/UserContextMiddlewareTest.php
@@ -83,9 +83,9 @@ class UserContextMiddlewareTest extends TestCase
         $this->get('test');
     }
 
-        /** @test */
-        public function it_does_not_set_action_for_invokable_controllers()
-        {
+    /** @test */
+    public function it_does_not_set_action_for_invokable_controllers()
+    {
         $honeybadger = $this->createMock(Honeybadger::class);
 
         $honeybadger->expects($this->once())
@@ -104,5 +104,5 @@ class UserContextMiddlewareTest extends TestCase
             });
 
         $this->get('test');
-        }
+    }
 }

--- a/tests/UserContextMiddlewareTest.php
+++ b/tests/UserContextMiddlewareTest.php
@@ -63,12 +63,13 @@ class UserContextMiddlewareTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_set_action_and_context()
+    public function it_does_not_set_action_for_a_closure()
     {
         $honeybadger = $this->createMock(Honeybadger::class);
 
-        $honeybadger->expects($this->never())
-            ->method('setComponent');
+        $honeybadger->expects($this->once())
+            ->method('setComponent')
+            ->with('Closure');
 
         $honeybadger->expects($this->never())
             ->method('setAction');
@@ -81,4 +82,27 @@ class UserContextMiddlewareTest extends TestCase
 
         $this->get('test');
     }
+
+        /** @test */
+        public function it_does_not_set_action_for_invokable_controllers()
+        {
+        $honeybadger = $this->createMock(Honeybadger::class);
+
+        $honeybadger->expects($this->once())
+            ->method('setComponent')
+            ->with('Honeybadger\Tests\Fixtures\TestInvokableController');
+
+        $honeybadger->expects($this->never())
+            ->method('setAction');
+
+        $this->app[Reporter::class] = $honeybadger;
+
+        Route::middleware(HoneybadgerContext::class)
+            ->namespace('Honeybadger\Tests\Fixtures')
+            ->group(function () {
+                Route::get('test', 'TestInvokableController');
+            });
+
+        $this->get('test');
+        }
 }


### PR DESCRIPTION
## Description
We needed to split up the checks for the component and the action. Laravel will set the component to 'Closure' for closure routes and will send the controller name for invokables.

Resolves #36 

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```