### PR TITLE
Remove Laravel 6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ matrix:
     - php: 7.3
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.3
-      env: LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
-    - php: 7.3
-      env: COVERAGE=1 LARAVEL='6.*' 'TESTBENCH='4.*'
+      env: COVERAGE=1 LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
   fast_finish: true
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Drops Laravel 6 support, need new major version
 
 ## [1.7.2] - 2019-09-05
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php": "^7.1",
         "honeybadger-io/honeybadger-php": "^1.7",
         "sixlive/dotenv-editor": "^1.1",
-        "illuminate/console": "^5.5|^6.0",
-        "illuminate/support": "^5.5|^6.0"
+        "illuminate/console": "^5.5",
+        "illuminate/support": "^5.5"
     },
     "require-dev": {
         "larapack/dd": "^1.0",


### PR DESCRIPTION
## Description
Laravel 6 has a minimum version for Monolog which is incompatible with
honeybadger-io/honeybadger-php. This library will need to utilize
honeybadger-php:^2.0 to allow support for Laravel 6.

## Related PRs
List related PRs against other branches:

- https://github.com/honeybadger-io/honeybadger-php/pull/91

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
