### PR TITLE
Version two base changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,28 +10,14 @@ env:
 
 matrix:
   include:
-    - php: 7.1
-      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
-    - php: 7.1
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
-    - php: 7.1
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
-    - php: 7.1
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.2
-      env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
+      env: LARAVEL='6.* 'TESTBENCH='4.*' COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
-      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
-    - php: 7.2
-      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
-    - php: 7.2
-      env: LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
+      env: LARAVEL='6.* 'TESTBENCH='4.*' COMPOSER_FLAGS=""
     - php: 7.3
-      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+      env: COVERAGE=1 LARAVEL='6.* 'TESTBENCH='4.*' COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.3
-      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
-    - php: 7.3
-      env: COVERAGE=1 LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
+      env: COVERAGE=1 LARAVEL='6.* 'TESTBENCH='4.*' COMPOSER_FLAGS=""
   fast_finish: true
 
 before_script:
@@ -40,7 +26,7 @@ before_script:
 
 before_install:
   - travis_retry composer self-update
-  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update ${COMPOSER_FLAGS}
 
 install:
   - travis_retry composer install --prefer-dist --no-interaction --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "honeybadger-io/honeybadger-php": "^1.7",
+        "php": "^7.2",
+        "honeybadger-io/honeybadger-php": "^2.0",
         "sixlive/dotenv-editor": "^1.1",
-        "illuminate/console": "^5.5",
-        "illuminate/support": "^5.5"
+        "illuminate/console": "^6.0",
+        "illuminate/support": "^6.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",


### PR DESCRIPTION
## Description
Version 2 base changes

- Update dependency minimum version
    - Laravel/Illuminate
    - Honeybadger PHP
- Removed support for PHP 7.1
- Removed support for Laravel/Illuminate 5.x
- Update Travis config to reflect new support

## Related PRs
### Depends on 
- https://github.com/honeybadger-io/honeybadger-laravel/pull/40
- https://github.com/honeybadger-io/honeybadger-php/pull/91

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```

1.
