### PR TITLE
Add pingHoneybadgerOnSuccess to scheduled tasks

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,7 +9,7 @@ $rules = [
     'not_operator_with_successor_space' => true,
     'no_useless_else' => true,
     'ordered_imports' => [
-        'sortAlgorithm' => 'length',
+        'sortAlgorithm' => 'alpha',
     ],
     'single_quote' => true,
     'ternary_operator_spaces' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `pingHoneybadgerOnSuccess` method to scheduled tasks
 
 ## [2.0.1] - 2019-10-01
 ### Fixed

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -3,15 +3,15 @@
 namespace Honeybadger\HoneybadgerLaravel;
 
 use GuzzleHttp\Client;
-use Honeybadger\Honeybadger;
 use Honeybadger\Contracts\Reporter;
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Console\Scheduling\Event;
-use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerTestCommand;
-use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerDeployCommand;
+use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckinCommand;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerDeployCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerInstallCommand;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerTestCommand;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer as InstallerContract;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Support\ServiceProvider;
 
 class HoneybadgerServiceProvider extends ServiceProvider
 {

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -109,5 +109,11 @@ class HoneybadgerServiceProvider extends ServiceProvider
                 app(Reporter::class)->checkin($id);
             });
         });
+
+        Event::macro('pingHoneybadgerOnSuccess', function ($id) {
+            return $this->onSuccess(function () use ($id) {
+                app(Reporter::class)->checkin($id);
+            });
+        });
     }
 }


### PR DESCRIPTION
## Description
Adds a new method for scheduled tasks to only ping Honeybadger's check-in when the task was successful. The current implementation (`thenPingHoneybadger()`) runs regardless of success or failure.

```php
protected function schedule(Schedule $schedule)
{
    $schedule->command('inspire')
        ->hourly()
        ->pingHoneybadgerOnSuccess('123456');
}
```

Closes #47 