### PR TITLE
Don't crash on service exception

### DIFF
--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -2,8 +2,10 @@
 
 namespace Honeybadger\HoneybadgerLaravel;
 
-use Honeybadger\Contracts\Reporter;
 use Honeybadger\Honeybadger;
+use Honeybadger\Contracts\Reporter;
+use Illuminate\Support\Facades\Log;
+use Honeybadger\Exceptions\ServiceException;
 
 class HoneybadgerLaravel
 {
@@ -12,10 +14,11 @@ class HoneybadgerLaravel
     /**
      * Honeybadger factory.
      *
-     * @param  array  $config
+     * @param array $config
+     *
      * @return \Honeybadger\Contracts\Reporter
      */
-    public function make($config): Reporter
+    public function make(array $config): Reporter
     {
         return Honeybadger::new(array_merge([
             'notifier' => [
@@ -23,6 +26,9 @@ class HoneybadgerLaravel
                 'url' => 'https://github.com/honeybadger-io/honeybadger-laravel',
                 'version' => self::VERSION,
             ],
+            'service_exception_handler' => function (ServiceException $e) {
+                Log::error($e);
+            },
         ], $config));
     }
 }

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -2,10 +2,10 @@
 
 namespace Honeybadger\HoneybadgerLaravel;
 
-use Honeybadger\Honeybadger;
 use Honeybadger\Contracts\Reporter;
-use Illuminate\Support\Facades\Log;
 use Honeybadger\Exceptions\ServiceException;
+use Honeybadger\Honeybadger;
+use Illuminate\Support\Facades\Log;
 
 class HoneybadgerLaravel
 {


### PR DESCRIPTION
## Status
**READY**

## Description
When the SDK can't send data to the backend (e.g. invalid API key, SSL verification failed, network problems), a `ServiceException` is thrown This PR will log the service exception rather than letting it crash the app and [hide the original exception](https://github.com/honeybadger-io/honeybadger-php/pull/129)..

Fixes https://github.com/honeybadger-io/honeybadger-php/pull/129.

## Related PRs
PHP: https://github.com/honeybadger-io/honeybadger-php/pull/129


## Steps to Test or Reproduce
- Add a route that throws an exception:
  ```php
  Route::get('/', function () {
      throw new \Exception("Oh fuck no!");
  });
  ```
- Set an invalid API key in your .env: `HONEYBADGER_API_KEY=dfdfdwrerrrrrrrrrr`
- Start the app: `php artisan serve`
- Visit the app on http://127.0.0.1:8000. The service exception should be logged in `storage/logs/laravel.log`
