### PR TITLE
Update install and test commands to fail loudly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Honeybadger Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <php>
-        <env name="APP_KEY" value="base64:hwRkvdrUmW5PoNBh+H0KgUqmSOivZbFd5gW7IPHztmY="/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Honeybadger Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <php>
+    <env name="APP_KEY" value="base64:hwRkvdrUmW5PoNBh+H0KgUqmSOivZbFd5gW7IPHztmY="/>
+  </php>
 </phpunit>

--- a/src/CommandTasks.php
+++ b/src/CommandTasks.php
@@ -44,9 +44,6 @@ class CommandTasks
     /**
      * Add task with result to the stack.
      *
-     * @param  string  $name
-     * @param  callable  $task
-     * @return self
      */
     public function addTask(string $name, callable $task, bool $throwOnFail = false): self
     {

--- a/src/CommandTasks.php
+++ b/src/CommandTasks.php
@@ -43,7 +43,6 @@ class CommandTasks
 
     /**
      * Add task with result to the stack.
-     *
      */
     public function addTask(string $name, callable $task, bool $throwOnFail = false): self
     {

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -2,8 +2,6 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Commands;
 
-use Honeybadger\Exceptions\ServiceException;
-use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\CommandTasks;
 use Honeybadger\HoneybadgerLaravel\Concerns\RequiredInput;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer;
@@ -116,6 +114,7 @@ class HoneybadgerInstallCommand extends Command
             'Send test exception to Honeybadger',
             function () {
                 $result = $this->installer->sendTestException();
+
                 return empty($result) ? false : $result;
             },
             true

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -75,8 +75,7 @@ class HoneybadgerInstallCommand extends Command
 
         try {
             $this->tasks->runTasks();
-            $results = $this->tasks->getResults();
-            $testExceptionResult = end($results);
+            $testExceptionResult = $this->tasks->getResults()['Send test exception to Honeybadger'];
             $this->outputSuccessMessage(Arr::get($testExceptionResult, 'id', ''));
         } catch (TaskFailed $e) {
             $this->line('');

--- a/src/Commands/HoneybadgerTestCommand.php
+++ b/src/Commands/HoneybadgerTestCommand.php
@@ -24,13 +24,11 @@ class HoneybadgerTestCommand extends Command
      */
     protected $description = 'Tests notifications to Honeybadger';
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle(Reporter $honeybadger)
+    public function handle()
     {
+        /** @var Reporter $honeybadger */
+        $honeybadger = app('honeybadger.loud');
+
         try {
             $result = $honeybadger->notify(new TestException);
             $this->info('A test exception was sent to Honeybadger');

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -27,7 +27,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
             $this->app->bind(InstallerContract::class, Installer::class);
 
             $this->publishes([
-                __DIR__ . '/../config/honeybadger.php' => base_path('config/honeybadger.php'),
+                __DIR__.'/../config/honeybadger.php' => base_path('config/honeybadger.php'),
             ], 'config');
         }
 
@@ -39,7 +39,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/honeybadger.php', 'honeybadger');
+        $this->mergeConfigFrom(__DIR__.'/../config/honeybadger.php', 'honeybadger');
 
         $this->app->singleton(Reporter::class, function ($app) {
             return (new HoneybadgerLaravel)->make($app['config']['honeybadger']);

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -56,6 +56,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
             $config['service_exception_handler'] = function (ServiceException $e) {
                 throw $e;
             };
+
             return (new HoneybadgerLaravel)->make($config);
         });
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -37,10 +37,7 @@ class Installer implements InstallerContract
      */
     public function sendTestException(): array
     {
-        return App::makeWith(
-            Reporter::class,
-            ['config' => Config::get('honeybadger')]
-        )->notify(new TestException);
+        return app('honeybadger.loud')->notify(new TestException);
     }
 
     /**

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -2,12 +2,9 @@
 
 namespace Honeybadger\HoneybadgerLaravel;
 
-use Honeybadger\Contracts\Reporter;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer as InstallerContract;
 use Honeybadger\HoneybadgerLaravel\Exceptions\TestException;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use sixlive\DotenvEditor\DotenvEditor;
 

--- a/tests/Commands/HoneybadgerInstallCommandTest.php
+++ b/tests/Commands/HoneybadgerInstallCommandTest.php
@@ -51,9 +51,11 @@ class HoneybadgerInstallCommandTest extends TestCase
         $this->assertEquals([
             'Write HONEYBADGER_API_KEY to .env' => true,
             'Write HONEYBADGER_API_KEY placeholder to .env.example' => true,
-            'Publish the config file' => true,
-            'Send test exception to Honeybadger' => true,
             'Write HONEYBADGER_VERIFY_SSL placeholder to .env.example' => true,
+            'Publish the config file' => true,
+            'Send test exception to Honeybadger' => [
+                'id' => '1234'
+            ],
         ], $commandTasks->getResults());
     }
 
@@ -149,8 +151,8 @@ class HoneybadgerInstallCommandTest extends TestCase
 
         $this->artisan('honeybadger:install');
 
-        $this->assertTrue($commandTasks->getResults()['Send test exception to Honeybadger']);
-        $this->assertEquals(Config::get('honeybadger.api_key'), 'asdf123');
+        $this->assertEquals(['id' => '1234'], $commandTasks->getResults()['Send test exception to Honeybadger']);
+        $this->assertEquals('asdf123', Config::get('honeybadger.api_key'));
     }
 
     /** @test */
@@ -206,17 +208,18 @@ class HoneybadgerInstallCommandTest extends TestCase
     {
         $installer = $this->createMock(Installer::class);
 
+        $installer->method('shouldPublishConfig')
+            ->willReturn(false);
+        $installer->method('writeConfig')
+            ->willReturn(true);
         $installer->method('sendTestException')
             ->willReturn(['id' => '1234']);
 
         $this->app[Installer::class] = $installer;
 
-        $commandTasks = $this->createMock(CommandTasks::class);
-        $this->app[CommandTasks::class] = $commandTasks;
-
         $command = $this->getMockBuilder(HoneybadgerInstallCommand::class)
             ->disableOriginalClone()
-            ->setMethods([
+            ->onlyMethods([
                 'requiredSecret',
                 'confirm',
                 'line',

--- a/tests/Commands/HoneybadgerInstallCommandTest.php
+++ b/tests/Commands/HoneybadgerInstallCommandTest.php
@@ -54,7 +54,7 @@ class HoneybadgerInstallCommandTest extends TestCase
             'Write HONEYBADGER_VERIFY_SSL placeholder to .env.example' => true,
             'Publish the config file' => true,
             'Send test exception to Honeybadger' => [
-                'id' => '1234'
+                'id' => '1234',
             ],
         ], $commandTasks->getResults());
     }

--- a/tests/Commands/HoneybadgerTestCommandTest.php
+++ b/tests/Commands/HoneybadgerTestCommandTest.php
@@ -19,7 +19,7 @@ class HoneybadgerTestCommandTest extends TestCase
             ->method('notify')
             ->with($this->isInstanceOf(TestException::class));
 
-        $this->app->instance(Reporter::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $this->artisan('honeybadger:test');
     }
@@ -31,7 +31,7 @@ class HoneybadgerTestCommandTest extends TestCase
         $mock->method('notify')
             ->willReturn([]);
 
-        $this->app->instance(Reporter::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $command = $this->getMockBuilder(HoneybadgerTestCommand::class)
             ->disableOriginalClone()
@@ -52,9 +52,9 @@ class HoneybadgerTestCommandTest extends TestCase
     {
         $mock = $this->createMock(Reporter::class);
         $mock->method('notify')
-            ->will($this->throwException(new Exception('An error occured')));
+            ->will($this->throwException(new Exception('An error occurred')));
 
-        $this->app->instance(Reporter::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $command = $this->getMockBuilder(HoneybadgerTestCommand::class)
             ->disableOriginalClone()
@@ -63,11 +63,11 @@ class HoneybadgerTestCommandTest extends TestCase
 
         $command->expects($this->once())
             ->method('error')
-            ->with('An error occured');
+            ->with('An error occurred');
 
         $this->app[Kernel::class]->registerCommand($command);
 
-        $this->app->instance(Honeybadger::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $this->artisan('honeybadger:test');
     }
@@ -79,7 +79,7 @@ class HoneybadgerTestCommandTest extends TestCase
         $mock->method('notify')
             ->willReturn([]);
 
-        $this->app->instance(Reporter::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $command = $this->getMockBuilder(HoneybadgerTestCommand::class)
             ->disableOriginalClone()
@@ -92,7 +92,7 @@ class HoneybadgerTestCommandTest extends TestCase
 
         $this->app[Kernel::class]->registerCommand($command);
 
-        $this->app->instance(Honeybadger::class, $mock);
+        $this->app->instance('honeybadger.loud', $mock);
 
         $this->artisan('honeybadger:test');
     }

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -117,7 +117,7 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertMatchesRegularExpression('/500/', $e->getMessage());
+            $this->assertRegexp('/500/', $e->getMessage());
         }
     }
 
@@ -129,7 +129,7 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertMatchesRegularExpression('/{"status":"BAD"}/', $e->getMessage());
+            $this->assertRegexp('/{"status":"BAD"}/', $e->getMessage());
         }
     }
 }

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -117,7 +117,7 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertRegexp('/500/', $e->getMessage());
+            $this->assertMatchesRegularExpression('/500/', $e->getMessage());
         }
     }
 
@@ -129,7 +129,7 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertRegexp('/{"status":"BAD"}/', $e->getMessage());
+            $this->assertMatchesRegularExpression('/{"status":"BAD"}/', $e->getMessage());
         }
     }
 }

--- a/tests/Commands/InstallerTest.php
+++ b/tests/Commands/InstallerTest.php
@@ -3,7 +3,9 @@
 namespace Honeybadger\Tests\Commands;
 
 use Honeybadger\Contracts\Reporter;
+use Honeybadger\Exceptions\ServiceException;
 use Honeybadger\HoneybadgerLaravel\Exceptions\TestException;
+use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerServiceProvider;
 use Honeybadger\HoneybadgerLaravel\Installer;
 use Honeybadger\Tests\TestCase;
@@ -59,7 +61,7 @@ class InstallerTest extends TestCase
             ->method('notify')
             ->with($this->isInstanceOf(TestException::class));
 
-        $this->app[Reporter::class] = $honeybadger;
+        $this->app['honeybadger.loud'] = $honeybadger;
 
         $installer = new Installer;
 
@@ -71,11 +73,11 @@ class InstallerTest extends TestCase
     {
         $honeybadger = $this->createMock(Reporter::class);
 
-        $this->app[Reporter::class] = $honeybadger;
+        $this->app['honeybadger.loud'] = $honeybadger;
 
         $installer = new Installer;
 
-        $this->app->resolving(Reporter::class, function ($api, $app) {
+        $this->app->resolving('honeybadger.loud', function ($api, $app) {
             $this->assertEquals('asdf123', $app['config']['honeybadger']['api_key']);
         });
 

--- a/tests/Commands/InstallerTest.php
+++ b/tests/Commands/InstallerTest.php
@@ -3,9 +3,7 @@
 namespace Honeybadger\Tests\Commands;
 
 use Honeybadger\Contracts\Reporter;
-use Honeybadger\Exceptions\ServiceException;
 use Honeybadger\HoneybadgerLaravel\Exceptions\TestException;
-use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerServiceProvider;
 use Honeybadger\HoneybadgerLaravel\Installer;
 use Honeybadger\Tests\TestCase;


### PR DESCRIPTION
## Status
**READY**

## Description
Follow up to #70. The Honeybadger client shouldn't throw errors, but in certain cases (the `test` and `install` commands, we definitely want it to throw an error if there was a problem.

This PR achieves that by adding a separate `honeybadger.loud` binding to the DI container — another client instance, but one that will fail loudly (crash on errors).

(I had to refactor a few things internally to get it to work properly, but the behaviour of the command is the same.)