### PR TITLE
prepare for phpunit 10

### DIFF
--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -117,7 +117,13 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertRegexp('/500/', $e->getMessage());
+            if (method_exists($this, 'assertMatchesRegularExpression')) {
+                // PHPUnit 9 +
+                $this->assertMatchesRegularExpression('/500/', $e->getMessage());
+            } else {
+                // < PHPUnit 9
+                $this->assertRegexp('/500/', $e->getMessage());
+            }
         }
     }
 
@@ -129,7 +135,13 @@ class HoneybadgetDeployCommandTest extends TestCase
         try {
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
-            $this->assertRegexp('/{"status":"BAD"}/', $e->getMessage());
+            if (method_exists($this, 'assertMatchesRegularExpression')) {
+                // PHPUnit 9 +
+                $this->assertMatchesRegularExpression('/{"status":"BAD"}/', $e->getMessage());
+            } else {
+                // < PHPUnit 9
+                $this->assertRegexp('/{"status":"BAD"}/', $e->getMessage());
+            }
         }
     }
 }

--- a/tests/Commands/HoneybadgetDeployCommandTest.php
+++ b/tests/Commands/HoneybadgetDeployCommandTest.php
@@ -118,7 +118,7 @@ class HoneybadgetDeployCommandTest extends TestCase
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
             if (method_exists($this, 'assertMatchesRegularExpression')) {
-                // PHPUnit 9 +
+                // PHPUnit 9+
                 $this->assertMatchesRegularExpression('/500/', $e->getMessage());
             } else {
                 // < PHPUnit 9
@@ -136,7 +136,7 @@ class HoneybadgetDeployCommandTest extends TestCase
             $this->artisan('honeybadger:deploy');
         } catch (\Exception $e) {
             if (method_exists($this, 'assertMatchesRegularExpression')) {
-                // PHPUnit 9 +
+                // PHPUnit 9+
                 $this->assertMatchesRegularExpression('/{"status":"BAD"}/', $e->getMessage());
             } else {
                 // < PHPUnit 9


### PR DESCRIPTION
## Status
READY

## Description
Adds compatibility with PHPUnit 10

When running the tests PHPUnit gave this warning `assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.`

This PR does the recommended change, while still keeping compatibility with PHPUnit 8.