### PR TITLE
add $environments arguments to ping methods

### DIFF
--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -120,11 +120,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
         /** @param  string|array|null  $environments */
         Event::macro('thenPingHoneybadger', function (string $id, $environments = null) {
             return $this->then(function () use ($id, $environments) {
-                $shouldCheckin = $environments !== null
-                    ? app()->environment($environments)
-                    : true;
-
-                if ($shouldCheckin) {
+                if ($environments === null || app()->environment($environments)) {
                     app(Reporter::class)->checkin($id);
                 }
             });
@@ -133,11 +129,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
         /** @param  string|array|null  $environments */
         Event::macro('pingHoneybadgerOnSuccess', function (string $id, $environments = null) {
             return $this->onSuccess(function () use ($id, $environments) {
-                $shouldCheckin = $environments !== null
-                    ? app()->environment($environments)
-                    : true;
-
-                if ($shouldCheckin) {
+                if ($environments === null || app()->environment($environments)) {
                     app(Reporter::class)->checkin($id);
                 }
             });

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -117,15 +117,29 @@ class HoneybadgerServiceProvider extends ServiceProvider
      */
     private function registerMacros()
     {
-        Event::macro('thenPingHoneybadger', function ($id) {
-            return $this->then(function () use ($id) {
-                app(Reporter::class)->checkin($id);
+        /** @param  string|array|null  $environments */
+        Event::macro('thenPingHoneybadger', function (string $id, $environments = null) {
+            return $this->then(function () use ($id, $environments) {
+                $shouldCheckin = $environments !== null
+                    ? app()->environment($environments)
+                    : true;
+
+                if ($shouldCheckin) {
+                    app(Reporter::class)->checkin($id);
+                }
             });
         });
 
-        Event::macro('pingHoneybadgerOnSuccess', function ($id) {
-            return $this->onSuccess(function () use ($id) {
-                app(Reporter::class)->checkin($id);
+        /** @param  string|array|null  $environments */
+        Event::macro('pingHoneybadgerOnSuccess', function (string $id, $environments = null) {
+            return $this->onSuccess(function () use ($id, $environments) {
+                $shouldCheckin = $environments !== null
+                    ? app()->environment($environments)
+                    : true;
+
+                if ($shouldCheckin) {
+                    app(Reporter::class)->checkin($id);
+                }
             });
         });
     }

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -25,4 +25,49 @@ class HoneybadgerEventPingTest extends TestCase
 
         $this->artisan('schedule:run');
     }
+
+    /** @test */
+    public function scheduled_tasks_will_ping_honeybadger_if_matching_environments()
+    {
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->exactly(2))
+            ->method('checkin')
+            ->with('1234');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->thenPingHoneybadger('1234', 'testing');
+
+        $schedule->call(function () {
+            return true;
+        })->thenPingHoneybadger('1234', ['testing', 'production']);
+
+        $this->artisan('schedule:run');
+    }
+
+    /** @test */
+    public function scheduled_tasks_will_not_ping_honeybadger_if_non_matching_environments()
+    {
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->never())
+            ->method('checkin');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->thenPingHoneybadger('1234', 'development');
+
+        $schedule->call(function () {
+            return true;
+        })->thenPingHoneybadger('1234', ['development', 'production']);
+
+        $this->artisan('schedule:run');
+    }
 }

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -20,7 +20,7 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->thenPingHoneybadger('1234');
 
         $this->artisan('schedule:run');
@@ -39,11 +39,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->thenPingHoneybadger('1234', 'testing');
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->thenPingHoneybadger('1234', ['testing', 'production']);
 
         $this->artisan('schedule:run');
@@ -61,11 +61,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->thenPingHoneybadger('1234', 'development');
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->thenPingHoneybadger('1234', ['development', 'production']);
 
         $this->artisan('schedule:run');
@@ -84,11 +84,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->pingHoneybadgerOnSuccess('1234', 'testing');
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->pingHoneybadgerOnSuccess('1234', ['testing', 'production']);
 
         $this->artisan('schedule:run');
@@ -106,11 +106,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->pingHoneybadgerOnSuccess('1234', 'development');
 
         $schedule->call(function () {
-            return true;
+            return 0;
         })->pingHoneybadgerOnSuccess('1234', ['development', 'production']);
 
         $this->artisan('schedule:run');

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -72,8 +72,39 @@ class HoneybadgerEventPingTest extends TestCase
     }
 
     /** @test */
+    public function successful_tasks_will_ping_honeybadger()
+    {
+        if (version_compare($this->app->version(), '8.6.0', '<')) {
+            $this->markTestSkipped("Laravel < 8.6 doesn't set proper return codes for callables.");
+
+            return;
+        }
+
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->once())
+            ->method('checkin')
+            ->with('1234');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccess('1234');
+
+        $this->artisan('schedule:run');
+    }
+
+    /** @test */
     public function successful_tasks_will_ping_honeybadger_if_matching_environments()
     {
+        if (version_compare($this->app->version(), '8.6.0', '<')) {
+            $this->markTestSkipped("Laravel < 8.6 doesn't set proper return codes for callables.");
+
+            return;
+        }
+
         $schedule = $this->app[Schedule::class];
 
         $honeybadger = $this->createMock(Reporter::class);
@@ -97,6 +128,12 @@ class HoneybadgerEventPingTest extends TestCase
     /** @test */
     public function successful_tasks_will_not_ping_honeybadger_if_non_matching_environments()
     {
+        if (version_compare($this->app->version(), '8.6.0', '<')) {
+            $this->markTestSkipped("Laravel < 8.6 doesn't set proper return codes for callables.");
+
+            return;
+        }
+
         $schedule = $this->app[Schedule::class];
 
         $honeybadger = $this->createMock(Reporter::class);

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -20,7 +20,7 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->thenPingHoneybadger('1234');
 
         $this->artisan('schedule:run');
@@ -39,11 +39,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->thenPingHoneybadger('1234', 'testing');
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->thenPingHoneybadger('1234', ['testing', 'production']);
 
         $this->artisan('schedule:run');
@@ -61,11 +61,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->thenPingHoneybadger('1234', 'development');
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->thenPingHoneybadger('1234', ['development', 'production']);
 
         $this->artisan('schedule:run');
@@ -84,11 +84,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->pingHoneybadgerOnSuccess('1234', 'testing');
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->pingHoneybadgerOnSuccess('1234', ['testing', 'production']);
 
         $this->artisan('schedule:run');
@@ -106,11 +106,11 @@ class HoneybadgerEventPingTest extends TestCase
         $this->app->instance(Reporter::class, $honeybadger);
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->pingHoneybadgerOnSuccess('1234', 'development');
 
         $schedule->call(function () {
-            return 0;
+            return true;
         })->pingHoneybadgerOnSuccess('1234', ['development', 'production']);
 
         $this->artisan('schedule:run');

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -70,4 +70,49 @@ class HoneybadgerEventPingTest extends TestCase
 
         $this->artisan('schedule:run');
     }
+
+    /** @test */
+    public function successful_tasks_will_ping_honeybadger_if_matching_environments()
+    {
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->exactly(2))
+            ->method('checkin')
+            ->with('1234');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccess('1234', 'testing');
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccess('1234', ['testing', 'production']);
+
+        $this->artisan('schedule:run');
+    }
+
+    /** @test */
+    public function successful_tasks_will_not_ping_honeybadger_if_non_matching_environments()
+    {
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->never())
+            ->method('checkin');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccess('1234', 'development');
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccess('1234', ['development', 'production']);
+
+        $this->artisan('schedule:run');
+    }
 }


### PR DESCRIPTION
## Status
READY

## Description
Adds a second argument to the `thenPingHoneybadger` and `pingHoneybadgerOnSuccess` methods that allows you to specify one or more environments when to checkin, it can be omitted to always checkin (current behaviour).

The PR includes tests.

I also added a `string` typehint for the $id argument, which should be 100% backwards compatible since the Reporter checkin method already does the same typehint.

## Examples
```php
$schedule->command(SendEmails::class)
        ->daily()
        ->thenPingHoneybadger('Jiy63Xw', 'production'); // will only checkin on production
```

```php
$schedule->command(SendEmails::class)
        ->daily()
        ->thenPingHoneybadger('Jiy63Xw', ['production', 'development']); // will only checkin on production and development
```
