### PR TITLE
ignore styleci config from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/.styleci.yml       export-ignore


### PR DESCRIPTION
## Status
READY

## Description
.styleci.yml should not be needed in the export, unless i'm totally mistaken (not a styleci user), but laravel/framework as an example does not export it.
