### PR TITLE
Include PHP SDK version in reports

### DIFF
--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -24,7 +24,7 @@ class HoneybadgerLaravel
             'notifier' => [
                 'name' => 'Honeybadger Laravel',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-laravel',
-                'version' => self::VERSION.' (PHP SDK: '.Honeybadger::VERSION.')',
+                'version' => self::VERSION.'/'.Honeybadger::VERSION,
             ],
             'service_exception_handler' => function (ServiceException $e) {
                 Log::error($e);

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -24,7 +24,7 @@ class HoneybadgerLaravel
             'notifier' => [
                 'name' => 'Honeybadger Laravel',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-laravel',
-                'version' => self::VERSION,
+                'version' => self::VERSION.' (PHP SDK: '.Honeybadger::VERSION.')',
             ],
             'service_exception_handler' => function (ServiceException $e) {
                 Log::error($e);


### PR DESCRIPTION
## Status
**READY**

## Description
Follow-up to a discussion on Slack with @stympy. This PR includes the base PHP SDK's version in reports (helpful for debugging purposes).

Question: is the current `version` field used anywhere on the backend (example, comparing if `notifier.version == '3.5.0'`)? If it is, then this PR might break some behaviour; if not, we're good.