### PR TITLE
Update notifier name

### DIFF
--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -11,13 +11,13 @@ use Throwable;
 
 class HoneybadgerLaravel extends Honeybadger
 {
-    const VERSION = '3.7.0';
+    const VERSION = '3.8.0';
 
     public static function make(array $config): Reporter
     {
         return static::new(array_merge([
             'notifier' => [
-                'name' => 'Honeybadger Laravel',
+                'name' => 'honeybadger-laravel',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-laravel',
                 'version' => self::VERSION.'/'.Honeybadger::VERSION,
             ],


### PR DESCRIPTION
This changes `notice['notifier']['name']` to match the format of our
other client libraries (honeybadger-ruby, honeybadger-elixir, etc.).

Also bumps the version for local testing displaying breadcrumbs in
Honeybadger UI.