### PR TITLE
Silence any errors from breadcrumbs

### DIFF
--- a/src/Breadcrumbs/Breadcrumb.php
+++ b/src/Breadcrumbs/Breadcrumb.php
@@ -24,6 +24,10 @@ class Breadcrumb
             return;
         }
 
-        $this->handleEvent($event);
+        try {
+            $this->handleEvent($event);
+        } catch (\Throwable $e) {
+            // Do nothing; we shouldn't crash the user's app for this.
+        }
     }
 }


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

Fixes #80.

Since the breadcrumbs collection runs synchronously in the same process as the user's app (and on every request), it will crash their app if something goes wrong. This is obviously not desirable, so it's better to just silence errors instead.