### PR TITLE
Automatically add user and route context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Honeybadger can now set route action and user context automatically—no middleware needed ()
 
 ## [3.8.1] - 2021-03-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.9.0] - 2021-04-12
 ### Added
-- Honeybadger can now set route action and user context automatically—no middleware needed ()
+- Honeybadger can now set route action and user context automatically—no middleware needed ([#82](https://github.com/honeybadger-io/honeybadger-laravel/pull/82/))
 
 ## [3.8.1] - 2021-03-25
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "honeybadger-io/honeybadger-php": "^2.8.0",
+        "honeybadger-io/honeybadger-php": "^2.8.2",
         "sixlive/dotenv-editor": "^1.1",
         "illuminate/console": "^7.0|^8.0",
         "illuminate/support": "^7.0|^8.0",

--- a/src/ContextManager.php
+++ b/src/ContextManager.php
@@ -1,15 +1,12 @@
 <?php
 
-namespace Honeybadger\HoneybadgerLaravel\Middleware;
+namespace Honeybadger\HoneybadgerLaravel;
 
-use Closure;
 use Honeybadger\Contracts\Reporter;
 use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @deprecated Honeybadger adds the context automatically
- */
-class HoneybadgerContext
+class ContextManager
 {
     /**
      * @var \Honeybadger\Honeybadger;
@@ -24,27 +21,16 @@ class HoneybadgerContext
         $this->honeybadger = $honeybadger;
     }
 
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
-     */
-    public function handle($request, Closure $next)
+    public function setRouteAction(Request $request)
     {
-        $this->setUserContext($request);
-
         if (app('honeybadger.isLumen')) {
             $this->setLumenRouteActionContext($request);
         } else {
-            $this->setRouteActionContext();
+            $this->setLaravelRouteActionContext();
         }
-
-        return $next($request);
     }
 
-    private function setLumenRouteActionContext($request)
+    private function setLumenRouteActionContext(Request $request)
     {
         $routeDetails = app()->router->getRoutes()[$request->method().$request->getPathInfo()]['action'];
 
@@ -65,7 +51,7 @@ class HoneybadgerContext
         }
     }
 
-    private function setRouteActionContext()
+    private function setLaravelRouteActionContext()
     {
         if (Route::getCurrentRoute()) {
             $routeAction = explode('@', Route::getCurrentRoute()->getActionName());
@@ -80,7 +66,7 @@ class HoneybadgerContext
         }
     }
 
-    private function setUserContext($request)
+    public function setUserContext($request)
     {
         try {
             if ($request->user()) {

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -11,7 +11,7 @@ use Throwable;
 
 class HoneybadgerLaravel extends Honeybadger
 {
-    const VERSION = '3.8.1';
+    const VERSION = '3.9.1';
 
     // Don't forget to sync changes to this with the config file defaults
     const DEFAULT_BREADCRUMBS = [
@@ -49,6 +49,8 @@ class HoneybadgerLaravel extends Honeybadger
 
     public function notify(Throwable $throwable, Request $request = null, array $additionalParams = []): array
     {
+        $this->setRouteActionAndUserContext($request ?: request());
+
         $result = parent::notify($throwable, $request, $additionalParams);
 
         // Persist the most recent error for the rest of the request, so we can display on error page.
@@ -58,5 +60,17 @@ class HoneybadgerLaravel extends Honeybadger
         }
 
         return $result;
+    }
+
+    protected function setRouteActionAndUserContext(Request $request): void
+    {
+        // For backwards compatibility, check if context has already been set by the middleware
+        if ($this->context->get('user_id') === null
+            && $this->context->get('honeybadger_component') === null
+            && $this->context->get('honeybadger_action') === null) {
+            $contextManager = new ContextManager($this);
+            $contextManager->setRouteAction($request);
+            $contextManager->setUserContext($request);
+        }
     }
 }

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -11,7 +11,7 @@ use Throwable;
 
 class HoneybadgerLaravel extends Honeybadger
 {
-    const VERSION = '3.9.1';
+    const VERSION = '3.9.0';
 
     // Don't forget to sync changes to this with the config file defaults
     const DEFAULT_BREADCRUMBS = [

--- a/src/Middleware/HoneybadgerContext.php
+++ b/src/Middleware/HoneybadgerContext.php
@@ -33,12 +33,14 @@ class HoneybadgerContext
      */
     public function handle($request, Closure $next)
     {
-        $this->setUserContext($request);
+        if (app()->bound('honeybadger')) {
+            $this->setUserContext($request);
 
-        if (app('honeybadger.isLumen')) {
-            $this->setLumenRouteActionContext($request);
-        } else {
-            $this->setRouteActionContext();
+            if (app('honeybadger.isLumen')) {
+                $this->setLumenRouteActionContext($request);
+            } else {
+                $this->setRouteActionContext();
+            }
         }
 
         return $next($request);

--- a/src/Middleware/UserContext.php
+++ b/src/Middleware/UserContext.php
@@ -2,6 +2,9 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Middleware;
 
+/**
+ * @deprecated Honeybadger now adds the context automatically
+ */
 class UserContext extends HoneybadgerContext
 {
     // Backwards Compatibility

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -8,4 +8,10 @@ class TestController
     {
         return response()->json([]);
     }
+
+    public function recordException()
+    {
+        app('honeybadger')->notify(new \Exception('Test exception'));
+        return response()->json([]);
+    }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -12,6 +12,7 @@ class TestController
     public function recordException()
     {
         app('honeybadger')->notify(new \Exception('Test exception'));
+
         return response()->json([]);
     }
 }

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use GuzzleHttp\Psr7\Response;
+use Honeybadger\Contracts\Reporter;
+use Honeybadger\HoneybadgerClient;
+use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
+use Honeybadger\Tests\Fixtures\TestController;
+use Illuminate\Support\Facades\Route;
+
+class ReporterTest extends TestCase
+{
+    /** @test */
+    public function it_automatically_adds_the_user_context()
+    {
+        request()->setUserResolver(function () {
+            return new class {
+                public function getAuthIdentifier()
+                {
+                    return '1234';
+                }
+            };
+        });
+        $client = $this->createMock(HoneybadgerClient::class);
+        $client->expects($this->once())
+            ->method('notification')
+            ->withAnyParameters()
+            ->willReturnCallback(function ($notification) {
+                $this->assertEquals(['user_id' => '1234'], $notification['request']['context']);
+
+                return ['id' => 'ojuih86747909i6511c'];
+            });
+
+        $badger = HoneybadgerLaravel::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ]);
+        $reflectedBadger = new \ReflectionClass($badger);
+        $reflectedClient = $reflectedBadger->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($badger, $client);
+        $this->app[Reporter::class] = $badger;
+
+        $badger->notify(new \Exception('Test exception'));
+    }
+
+    /** @test */
+    public function it_automatically_sets_action_and_context()
+    {
+        request()->setUserResolver(function () {
+            return new class {
+                public function getAuthIdentifier()
+                {
+                    return '1234';
+                }
+            };
+        });
+        $client = $this->createMock(HoneybadgerClient::class);
+        $client->expects($this->once())
+            ->method('notification')
+            ->withAnyParameters()
+            ->willReturnCallback(function ($notification) {
+                $this->assertEquals('Honeybadger\Tests\Fixtures\TestController', $notification['request']['component']);
+                $this->assertEquals('recordException', $notification['request']['action']);
+
+                return ['id' => 'ojuih86747909i6511c'];
+            });
+
+        $badger = HoneybadgerLaravel::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ]);
+        $reflectedBadger = new \ReflectionClass($badger);
+        $reflectedClient = $reflectedBadger->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($badger, $client);
+        $this->app[Reporter::class] = $badger;
+
+        Route::get('/recordException', [TestController::class, 'recordException']);
+
+        $this->get('/recordException');
+    }
+
+}

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -86,5 +86,4 @@ class ReporterTest extends TestCase
 
         $this->get('/recordException');
     }
-
 }

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger\Tests;
 
-use GuzzleHttp\Psr7\Response;
 use Honeybadger\Contracts\Reporter;
 use Honeybadger\HoneybadgerClient;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;


### PR DESCRIPTION
## Status
**READY**

## Description
This PR removes the need for adding the `HoneybadgerContext` middleware. Instead, when reporting an error, the client will retrieve the context itself (user context and route action) and send. This is better because:
- No need setting context on each request; only set when we actually encounter an error
- Simpler setup

## Related PRs
- Docs PR (TODO)

## Steps to Test or Reproduce
Create a Laravel app set up with Honeybadger and user auth. Remove the `HoneybadgerContext` middleware. Get the app to throw an error. The user ID and route action info should be present in your dashboard.