### PR TITLE
Add report_data to config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,5 @@
 preset: laravel
 
 disabled:
+  - laravel_braces
   - single_class_element_per_statement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.10.0] - 2021-05-09
+### Added
+- Added `report_data` to default config ([#85](https://github.com/honeybadger-io/honeybadger-laravel/pull/85))
+
 ## [3.9.0] - 2021-04-12
 ### Added
 - Honeybadger can now set route action and user context automatically—no middleware needed ([#82](https://github.com/honeybadger-io/honeybadger-laravel/pull/82/))

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -16,7 +16,7 @@ return [
     /**
      * To disable exception reporting, set this to false.
      */
-    "report_data" => ! in_array(env('APP_ENV'), ['local', 'testing']),
+    'report_data' => ! in_array(env('APP_ENV'), ['local', 'testing']),
 
     /**
      * When reporting an exception, we'll automatically include relevant environment variables.

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -16,7 +16,7 @@ return [
     /**
      * To disable exception reporting, set this to false.
      */
-    "report_data" => !in_array(env('APP_ENV'), ["local", "testing"]),
+    "report_data" => ! in_array(env('APP_ENV'), ["local", "testing"]),
 
     /**
      * When reporting an exception, we'll automatically include relevant environment variables.

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -9,6 +9,16 @@ return [
     'api_key' => env('HONEYBADGER_API_KEY'),
 
     /**
+     * The application environment.
+     */
+    'environment_name' => env('APP_ENV'),
+
+    /**
+     * To disable exception reporting, set this to false.
+     */
+    "report_data" => !in_array(env('APP_ENV'), ["local", "testing"]),
+
+    /**
      * When reporting an exception, we'll automatically include relevant environment variables.
      * See the Environment Whitelist (https://docs.honeybadger.io/lib/php/reference/configuration.html#environment-whitelist) for details.
      * Use this section to filter or include env variables.
@@ -58,11 +68,6 @@ return [
      * The root directory of your project.
      */
     'project_root' => base_path(),
-
-    /**
-     * The application environment.
-     */
-    'environment_name' => env('APP_ENV'),
 
     /**
      * Older PHP functions use the Error class, while modern PHP mostly uses Exception.

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -16,7 +16,7 @@ return [
     /**
      * To disable exception reporting, set this to false.
      */
-    "report_data" => ! in_array(env('APP_ENV'), ["local", "testing"]),
+    "report_data" => ! in_array(env('APP_ENV'), ['local', 'testing']),
 
     /**
      * When reporting an exception, we'll automatically include relevant environment variables.

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -11,7 +11,7 @@ use Throwable;
 
 class HoneybadgerLaravel extends Honeybadger
 {
-    const VERSION = '3.9.0';
+    const VERSION = '3.10.0';
 
     // Don't forget to sync changes to this with the config file defaults
     const DEFAULT_BREADCRUMBS = [


### PR DESCRIPTION
## Status
**READY**

## Description
Closes #83

Sets `report_data` to default to excluding local and test environment. Decided against adding a separate "development environments" config, because the precedence can be confusing—does `report_data: true` mean "report data even if in these environments", or "report data only if *not* in these environments"? It's simpler to have one configuration to control reporting of data,