### PR TITLE
Set SSL default in .env during install (fix #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set HONEYBADGER_VERIFY_SSL default in .env during installation ([#94](https://github.com/honeybadger-io/honeybadger-php/pull/94))
 
 ## [3.12.1] - 2021-11-22
 ### Fixed
-- Install command: don't error when there's no base route ([#90](https://github.com/honeybadger-io/honeybadger-php/pull/90))
 
 ## [3.12.0] - 2021-07-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.12.1] - 2021-11-22
 ### Fixed
+- Install command: don't error when there's no base route ([#90](https://github.com/honeybadger-io/honeybadger-php/pull/90))
 
 ## [3.12.0] - 2021-07-02
 ### Added

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -136,7 +136,10 @@ class HoneybadgerInstallCommand extends Command
             'Write HONEYBADGER_API_KEY to .env',
             function () {
                 return $this->installer->writeConfig(
-                    ['HONEYBADGER_API_KEY' => $this->config['api_key']],
+                    [
+                        'HONEYBADGER_API_KEY' => $this->config['api_key'],
+                        'HONEYBADGER_VERIFY_SSL' => 'true'
+                    ],
                     base_path('.env')
                 );
             }
@@ -146,7 +149,10 @@ class HoneybadgerInstallCommand extends Command
             'Write HONEYBADGER_API_KEY placeholder to .env.example',
             function () {
                 return $this->installer->writeConfig(
-                    ['HONEYBADGER_API_KEY' => ''],
+                    [
+                        'HONEYBADGER_API_KEY' => '',
+                        'HONEYBADGER_VERIFY_SSL' => 'true'
+                    ],
                     base_path('.env.example')
                 );
             }

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -138,7 +138,7 @@ class HoneybadgerInstallCommand extends Command
                 return $this->installer->writeConfig(
                     [
                         'HONEYBADGER_API_KEY' => $this->config['api_key'],
-                        'HONEYBADGER_VERIFY_SSL' => 'true'
+                        'HONEYBADGER_VERIFY_SSL' => 'true',
                     ],
                     base_path('.env')
                 );
@@ -151,7 +151,7 @@ class HoneybadgerInstallCommand extends Command
                 return $this->installer->writeConfig(
                     [
                         'HONEYBADGER_API_KEY' => '',
-                        'HONEYBADGER_VERIFY_SSL' => 'true'
+                        'HONEYBADGER_VERIFY_SSL' => 'true',
                     ],
                     base_path('.env.example')
                 );


### PR DESCRIPTION
Fixes #88 by writing `HONEYBADGER_VERIFY_SSL=true` to `.env` as well.