### PR TITLE
Add support for PHP ^8.0 exclusively

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "honeybadger-io/honeybadger-php": "^2.8.2",
-        "sixlive/dotenv-editor": "^1.1",
+        "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^7.0|^8.0|^9.0",
         "illuminate/support": "^7.0|^8.0|^9.0",
         "monolog/monolog": "^2.0",


### PR DESCRIPTION
## Status
**READY**

## Description
`sixlive/dotenv-editor=^2.0` drops support for PHP 7, which `thenpingme/laravel=^3.0` uses. As a result, this package and `thenpingme/laravel` cannot currently be installed alongside each other.

## Related PRs
No related PRs or branches.

## Todos
- [NA] Tests
- [NA] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
composer create-project laravel/laravel hblaravel
cd hblaravel
composer require honeybadger-io/honeybadger-laravel
composer require thenpingme/laravel=^3.0
```
