### PR TITLE
Add id retrieval from config

### DIFF
--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -125,6 +125,36 @@ class HoneybadgerServiceProvider extends ServiceProvider
                 }
             });
         });
+
+        /** @param string|array|null $environments */
+        Event::macro('thenPingHoneybadgerFromConfig', function (string $configKey, $environments = null) {
+            $id = config($configKey);
+
+            if (! $id) {
+                return $this;
+            }
+
+            return $this->then(function () use ($id, $environments) {
+                if ($environments === null || app()->environment($environments)) {
+                    app(Reporter::class)->checkin($id);
+                }
+            });
+        });
+
+        /** @param string|array|null $environments */
+        Event::macro('pingHoneybadgerOnSuccessFromConfig', function (string $configKey, $environments = null) {
+            $id = config($configKey);
+
+            if (! $id) {
+                return $this;
+            }
+
+            return $this->onSuccess(function () use ($id, $environments) {
+                if ($environments === null || app()->environment($environments)) {
+                    app(Reporter::class)->checkin($id);
+                }
+            });
+        });
     }
 
     private function registerBladeDirectives()

--- a/tests/HoneybadgerEventPingTest.php
+++ b/tests/HoneybadgerEventPingTest.php
@@ -4,6 +4,7 @@ namespace Honeybadger\Tests;
 
 use Honeybadger\Contracts\Reporter;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Config;
 
 class HoneybadgerEventPingTest extends TestCase
 {
@@ -67,6 +68,27 @@ class HoneybadgerEventPingTest extends TestCase
         $schedule->call(function () {
             return true;
         })->thenPingHoneybadger('1234', ['development', 'production']);
+
+        $this->artisan('schedule:run');
+    }
+
+       /** @test */
+    public function scheduled_tasks_will_ping_honeybadger_with_id_from_config()
+    {
+        $schedule = $this->app[Schedule::class];
+
+        Config::set('test_id', '1234');
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->once())
+            ->method('checkin')
+            ->with('1234');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->thenPingHoneybadgerFromConfig('test_id');
 
         $this->artisan('schedule:run');
     }
@@ -149,6 +171,33 @@ class HoneybadgerEventPingTest extends TestCase
         $schedule->call(function () {
             return true;
         })->pingHoneybadgerOnSuccess('1234', ['development', 'production']);
+
+        $this->artisan('schedule:run');
+    }
+
+    /** @test */
+    public function successful_tasks_will_ping_honeybadger_with_id_from_config()
+    {
+        if (version_compare($this->app->version(), '8.6.0', '<')) {
+            $this->markTestSkipped("Laravel < 8.6 doesn't set proper return codes for callables.");
+
+            return;
+        }
+
+        Config::set('test_id', '1234');
+
+        $schedule = $this->app[Schedule::class];
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $honeybadger->expects($this->once())
+            ->method('checkin')
+            ->with('1234');
+
+        $this->app->instance(Reporter::class, $honeybadger);
+
+        $schedule->call(function () {
+            return true;
+        })->pingHoneybadgerOnSuccessFromConfig('test_id');
 
         $this->artisan('schedule:run');
     }


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Adds 2 new macros to allow pulling the Honeybadger checkin ID from a configuration key.  This allows storing the ID as an .env key=value and configuring it within a config file for the application.

Useful in situations where the same scheduled command is run in more than one environment but needs to be reported as discrete checkins to Honeybadger.  This allows the ID to vary independent of the schedule definition in Kernel.php, as long as the same configuration key is used.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
