### PR TITLE
refactor(check-ins): checkins to check-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.18.1] - 2023-11-15
+## [3.18.1] - 2023-11-16
 ### Refactored
 - Check-Ins: checkins to check-ins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.18.1] - 2023-11-15
+### Refactored
+- Check-Ins: checkins to check-ins
+
 ## [3.18.0] - 2023-10-27
 ### Added
 - Check-Ins: Add support for slug url

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "honeybadger-io/honeybadger-php": "^2.17.0",
+        "honeybadger-io/honeybadger-php": "dev-check_ins_refactor",
         "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "honeybadger-io/honeybadger-php": "dev-check_ins_refactor",
+        "honeybadger-io/honeybadger-php": "^2.17.2",
         "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",

--- a/src/Commands/HoneybadgerCheckInCommand.php
+++ b/src/Commands/HoneybadgerCheckInCommand.php
@@ -6,7 +6,7 @@ use Exception;
 use Honeybadger\Contracts\Reporter;
 use Illuminate\Console\Command;
 
-class HoneybadgerCheckinCommand extends Command
+class HoneybadgerCheckInCommand extends Command
 {
     /**
      * The name and signature of the console command.
@@ -31,9 +31,9 @@ class HoneybadgerCheckinCommand extends Command
     public function handle(Reporter $honeybadger)
     {
         try {
-            $idOrName = $this->checkinIdOrName();
+            $idOrName = $this->checkInIdOrName();
             $honeybadger->checkin($idOrName);
-            $this->info(sprintf('Checkin %s was sent to Honeybadger', $idOrName));
+            $this->info(sprintf('Check-in %s was sent to Honeybadger', $idOrName));
         } catch (Exception $e) {
             $this->error($e->getMessage());
         }
@@ -44,7 +44,7 @@ class HoneybadgerCheckinCommand extends Command
      *
      * @return string
      */
-    private function checkinIdOrName(): string
+    private function checkInIdOrName(): string
     {
         return is_array($this->argument('id'))
             ? $this->argument('id')[0]

--- a/src/Commands/HoneybadgerCheckInsSyncCommand.php
+++ b/src/Commands/HoneybadgerCheckInsSyncCommand.php
@@ -2,10 +2,10 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Commands;
 
-use Honeybadger\Contracts\SyncCheckins;
+use Honeybadger\Contracts\SyncCheckIns;
 use Illuminate\Console\Command;
 
-class HoneybadgerCheckinsSyncCommand extends Command
+class HoneybadgerCheckInsSyncCommand extends Command
 {
     /**
      * The name and signature of the console command.
@@ -19,18 +19,18 @@ class HoneybadgerCheckinsSyncCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Synchronize checkins to Honeybadger';
+    protected $description = 'Synchronize check-ins to Honeybadger';
 
     /**
      * Execute the console command.
      *
      * @return mixed
      */
-    public function handle(SyncCheckins $checkinsManager)
+    public function handle(SyncCheckIns $checkinsManager)
     {
-        $localCheckins = config('honeybadger.checkins', []);
-        $result = $checkinsManager->sync($localCheckins);
-        $this->info('Checkins were synchronized with Honeybadger.');
+        $localCheckIns = config('honeybadger.checkins', []);
+        $result = $checkinsManager->sync($localCheckIns);
+        $this->info('Check-ins were synchronized with Honeybadger.');
         $this->table(['Id', 'Name', 'Slug', 'Schedule Type', 'Report Period', 'Cron Schedule', 'Cron Timezone', 'Grace Period', 'Status'], array_map(function ($checkin) {
             return [
                 $checkin->id,

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class HoneybadgerLaravel extends Honeybadger
 {
-    const VERSION = '3.18.0';
+    const VERSION = '3.18.1';
 
     // Don't forget to sync changes to this with the config file defaults
     const DEFAULT_BREADCRUMBS = [

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -3,21 +3,20 @@
 namespace Honeybadger\HoneybadgerLaravel;
 
 use GuzzleHttp\Client;
-use Honeybadger\CheckinsManager;
-use Honeybadger\Contracts\SyncCheckins;
-use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckinsSyncCommand;
+use Honeybadger\CheckInsManager;
+use Honeybadger\Contracts\SyncCheckIns;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckInsSyncCommand;
 use Honeybadger\LogHandler;
 use Honeybadger\Honeybadger;
 use Honeybadger\Contracts\Reporter;
 use Honeybadger\Exceptions\ServiceException;
-use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckinCommand;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckInCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerDeployCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerInstallCommand;
 use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerTestCommand;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer as InstallerContract;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class HoneybadgerServiceProvider extends ServiceProvider
@@ -50,7 +49,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/honeybadger.php', 'honeybadger');
 
         $this->registerReporters();
-        $this->registerCheckinsSync();
+        $this->registerCheckInsSync();
 
         $this->app->bind(LogHandler::class, function ($app) {
             return new LogHandler($app[Reporter::class]);
@@ -95,12 +94,12 @@ class HoneybadgerServiceProvider extends ServiceProvider
 
         $this->app->bind(
             'command.honeybadger:checkin',
-            HoneybadgerCheckinCommand::class
+            HoneybadgerCheckInCommand::class
         );
 
         $this->app->bind(
             'command.honeybadger:checkins:sync',
-            HoneybadgerCheckinsSyncCommand::class
+            HoneybadgerCheckInsSyncCommand::class
         );
 
         $this->app->bind(
@@ -185,10 +184,10 @@ class HoneybadgerServiceProvider extends ServiceProvider
         }
     }
 
-    protected function registerCheckinsSync(): void
+    protected function registerCheckInsSync(): void
     {
-        $this->app->singleton(SyncCheckins::class, function ($app) {
-            return new CheckinsManager($app['config']['honeybadger']);
+        $this->app->singleton(SyncCheckIns::class, function ($app) {
+            return new CheckInsManager($app['config']['honeybadger']);
         });
     }
 

--- a/tests/Commands/HoneybadgerCheckInCommandTest.php
+++ b/tests/Commands/HoneybadgerCheckInCommandTest.php
@@ -5,12 +5,12 @@ namespace Honeybadger\Tests\Commands;
 use Exception;
 use Honeybadger\Contracts\Reporter;
 use Honeybadger\Honeybadger;
-use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckinCommand;
+use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerCheckInCommand;
 use Honeybadger\Tests\TestCase;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Config;
 
-class HoneybadgerCheckinCommandTest extends TestCase
+class HoneybadgerCheckInCommandTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -37,14 +37,14 @@ class HoneybadgerCheckinCommandTest extends TestCase
         $mock = $this->createMock(Reporter::class);
         $this->app->instance(Honeybadger::class, $mock);
 
-        $command = $this->getMockBuilder(HoneybadgerCheckinCommand::class)
+        $command = $this->getMockBuilder(HoneybadgerCheckInCommand::class)
             ->disableOriginalClone()
             ->setMethods(['info'])
             ->getMock();
 
         $command->expects($this->once())
             ->method('info')
-            ->with('Checkin 1234 was sent to Honeybadger');
+            ->with('Check-in 1234 was sent to Honeybadger');
 
         $this->app[Kernel::class]->registerCommand($command);
 
@@ -60,7 +60,7 @@ class HoneybadgerCheckinCommandTest extends TestCase
 
         $this->app->instance(Reporter::class, $mock);
 
-        $command = $this->getMockBuilder(HoneybadgerCheckinCommand::class)
+        $command = $this->getMockBuilder(HoneybadgerCheckInCommand::class)
             ->disableOriginalClone()
             ->setMethods(['error'])
             ->getMock();

--- a/tests/Commands/HoneybadgerCheckInsSyncCommandTest.php
+++ b/tests/Commands/HoneybadgerCheckInsSyncCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Honeybadger\Tests\Commands;
 
-use Honeybadger\Contracts\SyncCheckins;
+use Honeybadger\Contracts\SyncCheckIns;
 use Honeybadger\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 
-class HoneybadgerCheckinsSyncCommandTest extends TestCase
+class HoneybadgerCheckInsSyncCommandTest extends TestCase
 {
     const CHECKINS = [
         [
@@ -33,14 +33,14 @@ class HoneybadgerCheckinsSyncCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_reads_checkins_from_config()
+    public function it_reads_check_ins_from_config()
     {
-        $mock = $this->createMock(SyncCheckins::class);
+        $mock = $this->createMock(SyncCheckIns::class);
         $mock->expects($this->once())
             ->method('sync')
             ->with(self::CHECKINS);
 
-        $this->app->instance(SyncCheckins::class, $mock);
+        $this->app->instance(SyncCheckIns::class, $mock);
 
         $this->artisan('honeybadger:checkins:sync');
     }


### PR DESCRIPTION
## Status
**READY**

## Description
To keep the language consistent, this PR renames all references of checkins to check-ins or checkIns (depending on the context).

**Note**: To maintain backwards compatibility, I kept the `checkin` commands as they are.

## Todos
- [x] Rename all references of checkins to check-in[s] or checkIn[s]
- [x] Set honeybadger-php version at `2.17.2` when this [PR](https://github.com/honeybadger-io/honeybadger-php/pull/182) is merged
- [x] Changelog
- [x] Version bump
