### PR TITLE
feat: add support for eu endpoints with install command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "honeybadger-io/honeybadger-php": ">=2.20.0",
+        "honeybadger-io/honeybadger-php": ">=2.21.0",
         "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
@@ -61,11 +61,5 @@
                 "Honeybadger": "Honeybadger\\HoneybadgerLaravel\\Facades\\Honeybadger"
             }
         }
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/honeybadger-io/honeybadger-php.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "honeybadger-io/honeybadger-php": ">=2.19.5",
+        "honeybadger-io/honeybadger-php": ">=2.20.0",
         "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -15,6 +15,19 @@ return [
     'personal_auth_token' => env('HONEYBADGER_PERSONAL_AUTH_TOKEN'),
 
     /**
+     * The endpoint for the Honeybadger API.
+     * If you are using the EU region, set this to 'https://eu-api.honeybadger.io/v1'.
+     */
+    'endpoint' => env('HONEYBADGER_ENDPOINT', 'https://api.honeybadger.io/v1'),
+
+    /**
+     * The endpoint for the Honeybadger App.
+     * This is used to synchronize check-ins with Honeybadger.
+     * If you are using the EU region, set this to 'https://eu-app.honeybadger.io'.
+     */
+    'app_endpoint' => env('HONEYBADGER_APP_ENDPOINT', 'https://app.honeybadger.io'),
+
+    /**
      * The application environment.
      */
     'environment_name' => env('APP_ENV'),

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -16,9 +16,9 @@ return [
 
     /**
      * The endpoint for the Honeybadger API.
-     * If you are using the EU region, set this to 'https://eu-api.honeybadger.io/v1'.
+     * If you are using the EU region, set this to 'https://eu-api.honeybadger.io'.
      */
-    'endpoint' => env('HONEYBADGER_ENDPOINT', 'https://api.honeybadger.io/v1'),
+    'endpoint' => env('HONEYBADGER_ENDPOINT', 'https://api.honeybadger.io'),
 
     /**
      * The endpoint for the Honeybadger App.

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -1,6 +1,7 @@
 <?php
 
 use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
 
 return [
@@ -16,16 +17,16 @@ return [
 
     /**
      * The endpoint for the Honeybadger API.
-     * If you are using the EU region, set this to 'https://eu-api.honeybadger.io'.
+     * If you are using the EU region, set this to 'https://eu-api.honeybadger.io/'.
      */
-    'endpoint' => env('HONEYBADGER_ENDPOINT', 'https://api.honeybadger.io'),
+    'endpoint' => env('HONEYBADGER_ENDPOINT', Honeybadger::API_URL),
 
     /**
      * The endpoint for the Honeybadger App.
      * This is used to synchronize check-ins with Honeybadger.
-     * If you are using the EU region, set this to 'https://eu-app.honeybadger.io'.
+     * If you are using the EU region, set this to 'https://eu-app.honeybadger.io/'.
      */
-    'app_endpoint' => env('HONEYBADGER_APP_ENDPOINT', 'https://app.honeybadger.io'),
+    'app_endpoint' => env('HONEYBADGER_APP_ENDPOINT', Honeybadger::APP_URL),
 
     /**
      * The application environment.

--- a/src/Commands/HoneybadgerDeployCommand.php
+++ b/src/Commands/HoneybadgerDeployCommand.php
@@ -48,12 +48,15 @@ class HoneybadgerDeployCommand extends Command
     {
         $config = Config::get('honeybadger');
 
-        $endpoint = $config['endpoint'] ?? (Honeybadger::API_URL . 'v1');
+        $endpoint = $config['endpoint'] ?? Honeybadger::API_URL;
+        if (!str_ends_with($endpoint, '/')) {
+            $endpoint .= '/';
+        }
 
         $params = $this->resolveParams($config);
 
         $response = $this->client->post(
-            $endpoint . '/deploys',
+            $endpoint . 'v1/deploys',
             [
                 'form_params' => $params,
             ]

--- a/src/Commands/HoneybadgerDeployCommand.php
+++ b/src/Commands/HoneybadgerDeployCommand.php
@@ -48,7 +48,7 @@ class HoneybadgerDeployCommand extends Command
     {
         $config = Config::get('honeybadger');
 
-        $endpoint = $config['endpoint'] ?? Honeybadger::API_URL;
+        $endpoint = $config['endpoint'] ?? (Honeybadger::API_URL . 'v1');
 
         $params = $this->resolveParams($config);
 

--- a/src/Commands/HoneybadgerDeployCommand.php
+++ b/src/Commands/HoneybadgerDeployCommand.php
@@ -3,6 +3,7 @@
 namespace Honeybadger\HoneybadgerLaravel\Commands;
 
 use GuzzleHttp\Client;
+use Honeybadger\Honeybadger;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\Response;
@@ -45,10 +46,14 @@ class HoneybadgerDeployCommand extends Command
      */
     public function handle()
     {
-        $params = $this->resolveParams();
+        $config = Config::get('honeybadger');
+
+        $endpoint = $config['endpoint'] ?? Honeybadger::API_URL;
+
+        $params = $this->resolveParams($config);
 
         $response = $this->client->post(
-            'https://api.honeybadger.io/v1/deploys',
+            $endpoint . '/deploys',
             [
                 'form_params' => $params,
             ]
@@ -66,10 +71,8 @@ class HoneybadgerDeployCommand extends Command
         $this->info(sprintf('Deployment %s successfully sent', $params['deploy']['revision']));
     }
 
-    private function resolveParams(): array
+    private function resolveParams($config): array
     {
-        $config = Config::get('honeybadger');
-
         return [
             'api_key' => $this->option('apiKey') ?? $config['api_key'],
             'deploy' => array_merge([

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Commands;
 
-use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\CommandTasks;
 use Honeybadger\HoneybadgerLaravel\Concerns\RequiredInput;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer;
@@ -15,12 +14,15 @@ class HoneybadgerInstallCommand extends Command
 {
     use RequiredInput;
 
+    private const HONEYBADGER_API_URL_EU = "https://eu-api.honeybadger.io/v1";
+    private const HONEYBADGER_APP_URL_EU = "https://eu-app.honeybadger.io";
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'honeybadger:install {apiKey?} {--endpoint=} {--appEndpoint=}';
+    protected $signature = 'honeybadger:install {apiKey?} {--eu} {--endpoint=} {--appEndpoint=}';
 
     /**
      * The console command description.
@@ -92,6 +94,12 @@ class HoneybadgerInstallCommand extends Command
         $config = [
             'api_key' => $this->argument('apiKey') ?? $this->promptForApiKey(),
         ];
+
+        $euStack = $this->option('eu');
+        if ($euStack) {
+            $config['endpoint'] = self::HONEYBADGER_API_URL_EU;
+            $config['app_endpoint'] = self::HONEYBADGER_APP_URL_EU;
+        }
 
         $endpoint = $this->option('endpoint');
         if ($endpoint != null) {
@@ -170,7 +178,7 @@ class HoneybadgerInstallCommand extends Command
             }
         );
 
-        if (isset($this->config['endpoint']) && $this->config['endpoint'] != Honeybadger::API_URL) {
+        if (isset($this->config['endpoint'])) {
             $this->tasks->addTask(
                 'Write HONEYBADGER_ENDPOINT to .env',
                 function () {
@@ -191,7 +199,7 @@ class HoneybadgerInstallCommand extends Command
             );
         }
 
-        if (isset($this->config['app_endpoint']) && $this->config['app_endpoint'] != Honeybadger::APP_URL) {
+        if (isset($this->config['app_endpoint'])) {
             $this->tasks->addTask(
                 'Write HONEYBADGER_APP_ENDPOINT to .env',
                 function () {

--- a/src/Commands/HoneybadgerInstallCommand.php
+++ b/src/Commands/HoneybadgerInstallCommand.php
@@ -14,15 +14,12 @@ class HoneybadgerInstallCommand extends Command
 {
     use RequiredInput;
 
-    private const HONEYBADGER_API_URL_EU = "https://eu-api.honeybadger.io/v1";
-    private const HONEYBADGER_APP_URL_EU = "https://eu-app.honeybadger.io";
-
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'honeybadger:install {apiKey?} {--eu} {--endpoint=} {--appEndpoint=}';
+    protected $signature = 'honeybadger:install {apiKey?} {--endpoint=} {--appEndpoint=}';
 
     /**
      * The console command description.
@@ -94,12 +91,6 @@ class HoneybadgerInstallCommand extends Command
         $config = [
             'api_key' => $this->argument('apiKey') ?? $this->promptForApiKey(),
         ];
-
-        $euStack = $this->option('eu');
-        if ($euStack) {
-            $config['endpoint'] = self::HONEYBADGER_API_URL_EU;
-            $config['app_endpoint'] = self::HONEYBADGER_APP_URL_EU;
-        }
 
         $endpoint = $this->option('endpoint');
         if ($endpoint != null) {

--- a/src/Commands/HoneybadgerTestCommand.php
+++ b/src/Commands/HoneybadgerTestCommand.php
@@ -4,6 +4,7 @@ namespace Honeybadger\HoneybadgerLaravel\Commands;
 
 use Exception;
 use Honeybadger\Contracts\Reporter;
+use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\Exceptions\TestException;
 use Illuminate\Console\Command;
 
@@ -39,7 +40,12 @@ class HoneybadgerTestCommand extends Command
                 throw new Exception('There was an error sending the exception to Honeybadger');
             }
 
-            $noticeUrl = "https://app.honeybadger.io/notice/$id";
+            $appEndpoint = config('honeybadger.app_endpoint') ?? Honeybadger::APP_URL;
+            if (!str_ends_with($appEndpoint, '/')) {
+                $appEndpoint .= '/';
+            }
+
+            $noticeUrl = $appEndpoint . "notice/$id";
             $this->info("Successfully sent a test exception to Honeybadger: $noticeUrl");
         } catch (Exception $e) {
             $this->error($e->getMessage());

--- a/tests/Commands/HoneybadgerInstallCommandTest.php
+++ b/tests/Commands/HoneybadgerInstallCommandTest.php
@@ -114,51 +114,6 @@ class HoneybadgerInstallCommandTest extends TestCase
     }
 
     /** @test */
-    public function writes_endpoint_values_to_env_files_with_eu_option()
-    {
-        $installer = $this->createMock(Installer::class);
-
-        $installer->method('sendTestException')
-            ->willReturn(['id' => '1234']);
-
-        $installer->method('writeConfig')
-            ->willReturn(true);
-
-        $installer->method('shouldPublishConfig')
-            ->willReturn(true);
-
-        $installer->method('publishLaravelConfig')
-            ->willReturn(true);
-
-        $this->app[Installer::class] = $installer;
-
-        $commandTasks = new CommandTasks;
-
-        $commandTasks->doNotThrowOnError();
-
-        $this->app[CommandTasks::class] = $commandTasks;
-
-        $command = $this->commandMock();
-
-        $this->app[Kernel::class]->registerCommand($command);
-
-        $this->artisan('honeybadger:install supersecret --eu');
-
-        $this->assertEquals([
-            'Write HONEYBADGER_API_KEY to .env' => true,
-            'Write HONEYBADGER_API_KEY and HONEYBADGER_VERIFY_SSL placeholders to .env.example' => true,
-            'Write HONEYBADGER_ENDPOINT to .env' => true,
-            'Write HONEYBADGER_ENDPOINT to .env.example' => true,
-            'Write HONEYBADGER_APP_ENDPOINT to .env' => true,
-            'Write HONEYBADGER_APP_ENDPOINT to .env.example' => true,
-            'Publish the config file' => true,
-            'Send test exception to Honeybadger' => [
-                'id' => '1234',
-            ],
-        ], $commandTasks->getResults());
-    }
-
-    /** @test */
     public function the_correct_config_gets_published_for_lumen()
     {
         $this->app['honeybadger.isLumen'] = true;

--- a/tests/Commands/HoneybadgerInstallCommandTest.php
+++ b/tests/Commands/HoneybadgerInstallCommandTest.php
@@ -57,7 +57,6 @@ class HoneybadgerInstallCommandTest extends TestCase
         $this->assertEquals([
             'Write HONEYBADGER_API_KEY to .env' => true,
             'Write HONEYBADGER_API_KEY and HONEYBADGER_VERIFY_SSL placeholders to .env.example' => true,
-            'Write HONEYBADGER_API_KEY placeholder to .env.example' => true,
             'Publish the config file' => true,
             'Send test exception to Honeybadger' => [
                 'id' => '1234',
@@ -237,7 +236,7 @@ class HoneybadgerInstallCommandTest extends TestCase
         $taskResults = $commandTasks->getResults();
 
         $this->assertFalse($taskResults['Write HONEYBADGER_API_KEY to .env']);
-        $this->assertFalse($taskResults['Write HONEYBADGER_API_KEY placeholder to .env.example']);
+        $this->assertFalse($taskResults['Write HONEYBADGER_API_KEY and HONEYBADGER_VERIFY_SSL placeholders to .env.example']);
     }
 
     /** @test */

--- a/tests/Commands/HoneybadgerInstallCommandTest.php
+++ b/tests/Commands/HoneybadgerInstallCommandTest.php
@@ -114,6 +114,51 @@ class HoneybadgerInstallCommandTest extends TestCase
     }
 
     /** @test */
+    public function writes_endpoint_values_to_env_files_with_eu_option()
+    {
+        $installer = $this->createMock(Installer::class);
+
+        $installer->method('sendTestException')
+            ->willReturn(['id' => '1234']);
+
+        $installer->method('writeConfig')
+            ->willReturn(true);
+
+        $installer->method('shouldPublishConfig')
+            ->willReturn(true);
+
+        $installer->method('publishLaravelConfig')
+            ->willReturn(true);
+
+        $this->app[Installer::class] = $installer;
+
+        $commandTasks = new CommandTasks;
+
+        $commandTasks->doNotThrowOnError();
+
+        $this->app[CommandTasks::class] = $commandTasks;
+
+        $command = $this->commandMock();
+
+        $this->app[Kernel::class]->registerCommand($command);
+
+        $this->artisan('honeybadger:install supersecret --eu');
+
+        $this->assertEquals([
+            'Write HONEYBADGER_API_KEY to .env' => true,
+            'Write HONEYBADGER_API_KEY and HONEYBADGER_VERIFY_SSL placeholders to .env.example' => true,
+            'Write HONEYBADGER_ENDPOINT to .env' => true,
+            'Write HONEYBADGER_ENDPOINT to .env.example' => true,
+            'Write HONEYBADGER_APP_ENDPOINT to .env' => true,
+            'Write HONEYBADGER_APP_ENDPOINT to .env.example' => true,
+            'Publish the config file' => true,
+            'Send test exception to Honeybadger' => [
+                'id' => '1234',
+            ],
+        ], $commandTasks->getResults());
+    }
+
+    /** @test */
     public function the_correct_config_gets_published_for_lumen()
     {
         $this->app['honeybadger.isLumen'] = true;


### PR DESCRIPTION
## Status
**READY**

## Description
- Adds configurable endpoints in config file.
- Adds optional parameters to _install_ command for endpoint and app endpoint.

The install command for HB EU becomes:
```
php artisan honeybadger:install API_KEY --endpoint https://eu-api.honeybadger.io --appEndpoint https://eu-app.honeybadger.io
```

Closes #137.

## Todos
- [x] Tests
- [x] Manual Testing
- [x] Documentation - https://github.com/honeybadger-io/docs/pull/546