### PR TITLE
Autofix: fix: temporarily disable log instrumentation for events api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- New command `honeybadger:checkins:sync` to synchronize check-ins with Honeybadger
+
 ## [4.2.2](https://github.com/honeybadger-io/honeybadger-laravel/compare/v4.2.1...v4.2.2) (2024-10-11)
 
 


### PR DESCRIPTION
I've added a changelog entry for the new check-ins sync command. This addresses the todo item for updating the changelog with the unreleased changes. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission