### PR TITLE
fix: stop using the MessageLogged event for events api

### DIFF
--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -117,7 +117,7 @@ return [
          * Events which should automatically be recorded by the Honeybadger client as breadcrumbs.
          * Note that to track redis events, you need to call `Redis::enableEvents()` in your app.
          */
-        'automatic' => HoneybadgerLaravel::DEFAULT_EVENTS,
+        'automatic' => HoneybadgerLaravel::DEFAULT_BREADCRUMB_EVENTS,
     ],
 
     /**

--- a/src/Events/ApplicationEvent.php
+++ b/src/Events/ApplicationEvent.php
@@ -63,7 +63,7 @@ abstract class ApplicationEvent
             return false;
         }
 
-        $eventsEnabled = config('honeybadger.breadcrumbs.automatic', HoneybadgerLaravel::DEFAULT_EVENTS);
+        $eventsEnabled = config('honeybadger.breadcrumbs.automatic', HoneybadgerLaravel::DEFAULT_BREADCRUMB_EVENTS);
         if (in_array(static::class, $eventsEnabled)) {
             return true;
         }

--- a/src/Events/MessageLogged.php
+++ b/src/Events/MessageLogged.php
@@ -2,8 +2,14 @@
 
 namespace Honeybadger\HoneybadgerLaravel\Events;
 
+use Honeybadger\HoneybadgerLaravel\HoneybadgerLogEventDriver;
 use Illuminate\Log\Events\MessageLogged as LaravelMessageLogged;
 
+/**
+ * Note: This event should not be used for the Events API.
+ * To send logs to Honeybadger Events API, use the {@link HoneybadgerLogEventDriver} as a log channel instead.
+ * The log channel driver comes with built-in support for log levels and infinite loop protection (it uses Monolog).
+ */
 class MessageLogged extends ApplicationEvent
 {
     public string $handles = LaravelMessageLogged::class;

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -25,7 +25,7 @@ class HoneybadgerLaravel extends Honeybadger
         Events\JobProcessed::class,
         Events\MailSending::class,
         Events\MailSent::class,
-        Events\MessageLogged::class,
+        // Events\MessageLogged::class,
         Events\NotificationSending::class,
         Events\NotificationSent::class,
         Events\NotificationFailed::class,
@@ -34,6 +34,11 @@ class HoneybadgerLaravel extends Honeybadger
         Events\RouteMatched::class,
         Events\RequestHandled::class,
         Events\ViewRendered::class,
+    ];
+
+    const DEFAULT_BREADCRUMB_EVENTS = [
+        ...self::DEFAULT_EVENTS,
+        Events\MessageLogged::class,
     ];
 
     public static function make(array $config): Reporter
@@ -45,9 +50,11 @@ class HoneybadgerLaravel extends Honeybadger
                 'version' => self::VERSION.'/'.Honeybadger::VERSION,
             ],
             'service_exception_handler' => function (ServiceException $e) {
-                // Note: If you are using Honeybadger as a Logger, this exception
-                // can end up being reported to Honeybadger depending on your log level configuration.
                 Log::warning($e);
+            },
+            'events_exception_handler' => function (ServiceException $e) {
+                // noop; we don't want to throw exceptions in the event handlers
+                // nor do we want to log them, because they will create a lot of noise.
             },
         ], $config));
     }

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -25,7 +25,6 @@ class HoneybadgerLaravel extends Honeybadger
         Events\JobProcessed::class,
         Events\MailSending::class,
         Events\MailSent::class,
-        // Events\MessageLogged::class,
         Events\NotificationSending::class,
         Events\NotificationSent::class,
         Events\NotificationFailed::class,

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -235,6 +235,9 @@ class HoneybadgerServiceProvider extends ServiceProvider
             $config['service_exception_handler'] = function (ServiceException $e) {
                 throw $e;
             };
+            $config['events_exception_handler'] = function (ServiceException $e) {
+                throw $e;
+            };
 
             return HoneybadgerLaravel::make($config);
         });


### PR DESCRIPTION
## Status
**READY**

## Description

### Context
The `MessageLogged` event was raised by Laravel and we were using it to send logs as events to Insights.
If there was an exception while sending the event to insights, we would do a Log::warning which would trigger the `MessageLogged` event and try to send an event to Insight again, causing an infinite loop. Note that the infinite loop wouldn't necessarily crash the app because the events are sent in batches (see `BulkEventDispatcher`), but the amount of logs would grow a lot.

### Solution

We also have another way to send logs as events Honeybadger Insights (manually configured), the `HoneybadgerLogEventDriver` which can be added as a separate log channel. This is a monolog handler which comes with built-in support for log levels and infinite loop protection. Hence, if you would end up in a situation as described above, monolog would catch it and ignore the log.
Even with this in mind, I still opted for a different handler for events exceptions, which by default is a no-op operation, to avoid the _scary_ infinite loop warning from monolog on production systems. The handler is configurable and users can override it in case they want to debug or do something else with the exception (i.e. they could log to a specific channel).
