### PR TITLE
perf: add PHP 8.4 to test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -23,9 +24,11 @@ jobs:
           - lowest
           - latest
         include:
+          - {php: '8.4', laravel: '11.*'}
           - {php: '8.3', laravel: '11.*'}
           - {php: '8.2', laravel: '11.*'}
 
+          - {php: '8.4', laravel: '10.*'}
           - {php: '8.3', laravel: '10.*'}
           - {php: '8.2', laravel: '10.*'}
           - {php: '8.1', laravel: '10.*'}

--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -58,7 +58,7 @@ class HoneybadgerLaravel extends Honeybadger
         ], $config));
     }
 
-    public function notify(Throwable $throwable, Request $request = null, array $additionalParams = []): array
+    public function notify(Throwable $throwable, ?Request $request = null, array $additionalParams = []): array
     {
         $this->setRouteActionAndUserContext($request ?: request());
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -58,7 +58,7 @@ class Installer implements InstallerContract
     /**
      * {@inheritdoc}
      */
-    public function publishLumenConfig(string $stubPath = null): bool
+    public function publishLumenConfig(?string $stubPath = null): bool
     {
         if (! is_dir(base_path('config'))) {
             mkdir(base_path('config'));


### PR DESCRIPTION
Same as with Honeybadger PHP library. Removed the deprecation warnings. There a lot of tests skipping. I'm not sure, if that was the default behaviour before 8.4.
