### PR TITLE
feat: allow disabling middleware from configuration

### DIFF
--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -3,6 +3,7 @@
 use Honeybadger\BulkEventDispatcher;
 use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
+use Honeybadger\HoneybadgerLaravel\Middleware\AssignRequestId;
 
 return [
     /**
@@ -165,4 +166,8 @@ return [
          */
         'automatic' => HoneybadgerLaravel::DEFAULT_EVENTS,
     ],
+
+    'middleware' => [
+        AssignRequestId::class
+    ]
 ];

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -245,7 +245,19 @@ class HoneybadgerServiceProvider extends ServiceProvider
 
     protected function registerMiddleware(): void
     {
+        $middleware = config('honeybadger.middleware', [
+            // the default middleware if the config is not found - this should happen for
+            // all versions of the package up to and including 4.3.1
+            Middleware\AssignRequestId::class,
+        ]);
+
+        if ($middleware == null || !is_array($middleware)) {
+            return;
+        }
+
         $kernel = app(Kernel::class);
-        $kernel->prependMiddleware(Middleware\AssignRequestId::class);
+        foreach ($middleware as $class) {
+            $kernel->prependMiddleware($class);
+        }
     }
 }


### PR DESCRIPTION


## Status
**READY**

## Description
Closes: #148.
Introduces a new config array, `middleware`, which allows users to define the middleware that should be registered by the package. By default and for backwards compatibility, the `AssignRequestId` middleware is registered, even if the configuration does not exist.