### PR TITLE
fix: get request instance using facade

### DIFF
--- a/src/HoneybadgerLaravel.php
+++ b/src/HoneybadgerLaravel.php
@@ -60,7 +60,11 @@ class HoneybadgerLaravel extends Honeybadger
 
     public function notify(Throwable $throwable, ?Request $request = null, array $additionalParams = []): array
     {
-        $this->setRouteActionAndUserContext($request ?: request());
+        $this->setRouteActionAndUserContext($request ?: \Illuminate\Support\Facades\Request::instance());
+
+        if (!$this->shouldReport($throwable)) {
+            return [];
+        }
 
         $result = parent::notify($throwable, $request, $additionalParams);
 


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #153.
- Get a `request` instance variable using the facade instead of the `request()` helper function.
- Additionally, adds a call to `HoneybadgerLaravel::shouldReport` before calling `Honeybadger::notify` (note: `Honeybadger::notify` calls `Honeybadger::shouldReport` as well).