### PR TITLE
feat: flushEvents with terminable middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "honeybadger-io/honeybadger-php": ">=2.24.0",
+        "honeybadger-io/honeybadger-php": ">=2.24.1",
         "sixlive/dotenv-editor": "^1.1|^2.0",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",

--- a/config/honeybadger.php
+++ b/config/honeybadger.php
@@ -4,6 +4,7 @@ use Honeybadger\BulkEventDispatcher;
 use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerLaravel\HoneybadgerLaravel;
 use Honeybadger\HoneybadgerLaravel\Middleware\AssignRequestId;
+use Honeybadger\HoneybadgerLaravel\Middleware\FlushEvents;
 
 return [
     /**
@@ -173,6 +174,7 @@ return [
     ],
 
     'middleware' => [
-        AssignRequestId::class
-    ]
+        AssignRequestId::class,
+        FlushEvents::class,
+    ],
 ];

--- a/src/Facades/Honeybadger.php
+++ b/src/Facades/Honeybadger.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static void event(string|array $eventTypeOrPayload, array $payload = null)
+ * @method static void flushEvents()
  * @method static void checkin(string $key)
  * @method static array rawNotification(callable $callable)
  * @method static array customNotification(array $payload)

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -18,6 +18,7 @@ use Honeybadger\HoneybadgerLaravel\Commands\HoneybadgerTestCommand;
 use Honeybadger\HoneybadgerLaravel\Contracts\Installer as InstallerContract;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
@@ -220,8 +221,16 @@ class HoneybadgerServiceProvider extends ServiceProvider
 
     protected function registerReporters(): void
     {
-        $this->app->singleton(Reporter::class, function ($app) {
-            return HoneybadgerLaravel::make($app['config']['honeybadger']);
+        $this->app->singleton(Reporter::class, function (Application $app) {
+            $config = $app['config']['honeybadger'];
+            if (!isset($config['handlers'])) {
+                $config['handlers'] = [];
+            }
+            // We only want the shutdown handler (to send events) when the app is running through a CLI command (i.e. queue:work).
+            // When the app is running normally, we register the FlushEvents middleware to send events.
+            $config['handlers']['shutdown'] = $app->runningInConsole();
+
+            return HoneybadgerLaravel::make($config);
         });
 
         $this->app->alias(Reporter::class, Honeybadger::class);
@@ -269,20 +278,21 @@ class HoneybadgerServiceProvider extends ServiceProvider
     {
         $middleware = config('honeybadger.middleware', [
             // the default middleware if the config is not found - this should happen for
-            // all versions of the package up to and including 4.3.1
+            // all versions of the package up to and including 4.3.1.
             Middleware\AssignRequestId::class,
             Middleware\FlushEvents::class,
         ]);
 
         if ($middleware == null || !is_array($middleware)) {
-            // We could consider null a valid value to indicate no middleware should be registered,
-            // not even the FlushEvents middleware.
+            // Note: We could consider null a valid value to indicate no middleware should be registered,
+            //       not even the FlushEvents middleware,
+            //       but we default to registering them if events are enabled (see below).
             $middleware = [];
         }
 
         // For versions greater than 4.3.1 until 4.6.0, the middleware config did not include FlushEvents,
-        // but we always want to flush events at the end of the request, regardless of the config.
-        if (!in_array(Middleware\FlushEvents::class, $middleware)) {
+        // but we always want to flush events at the end of the request, if they are enabled.
+        if (config('honeybadger.events.enabled') && !in_array(Middleware\FlushEvents::class, $middleware)) {
             $middleware[] = Middleware\FlushEvents::class;
         }
 

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -249,7 +249,14 @@ class HoneybadgerServiceProvider extends ServiceProvider
             // the default middleware if the config is not found - this should happen for
             // all versions of the package up to and including 4.3.1
             Middleware\AssignRequestId::class,
+            Middleware\FlushEvents::class,
         ]);
+
+        // For versions greater than 4.3.1 until 4.6.0, the middleware config did not include FlushEvents,
+        // but we always want to flush events at the end of the request, regardless of the config.
+        if (!in_array(Middleware\FlushEvents::class, $middleware)) {
+            $middleware[] = Middleware\FlushEvents::class;
+        }
 
         if ($middleware == null || !is_array($middleware)) {
             return;
@@ -257,7 +264,15 @@ class HoneybadgerServiceProvider extends ServiceProvider
 
         $kernel = app(Kernel::class);
         foreach ($middleware as $class) {
-            $kernel->prependMiddleware($class);
+            if ($class === Middleware\FlushEvents::class) {
+                // We prefer to append FlushEvents middleware at the bottom of the stack.
+                // Hopefully it the terminate method will be called after all other middleware.
+                $kernel->pushMiddleware($class);
+            }
+            else {
+                // For all other middleware, we prefer to have them at the top of the stack.
+                $kernel->prependMiddleware($class);
+            }
         }
     }
 }

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -245,20 +245,9 @@ class HoneybadgerServiceProvider extends ServiceProvider
 
     protected function registerMiddleware(): void
     {
-        $middleware = config('honeybadger.middleware', [
-            // the default middleware if the config is not found - this should happen for
-            // all versions of the package up to and including 4.3.1
-            Middleware\AssignRequestId::class,
-            Middleware\FlushEvents::class,
-        ]);
+        $middleware = $this->getMiddleware();
 
-        // For versions greater than 4.3.1 until 4.6.0, the middleware config did not include FlushEvents,
-        // but we always want to flush events at the end of the request, regardless of the config.
-        if (!in_array(Middleware\FlushEvents::class, $middleware)) {
-            $middleware[] = Middleware\FlushEvents::class;
-        }
-
-        if ($middleware == null || !is_array($middleware)) {
+        if (empty($middleware)) {
             return;
         }
 
@@ -274,5 +263,29 @@ class HoneybadgerServiceProvider extends ServiceProvider
                 $kernel->prependMiddleware($class);
             }
         }
+    }
+
+    private function getMiddleware(): array
+    {
+        $middleware = config('honeybadger.middleware', [
+            // the default middleware if the config is not found - this should happen for
+            // all versions of the package up to and including 4.3.1
+            Middleware\AssignRequestId::class,
+            Middleware\FlushEvents::class,
+        ]);
+
+        if ($middleware == null || !is_array($middleware)) {
+            // We could consider null a valid value to indicate no middleware should be registered,
+            // not even the FlushEvents middleware.
+            $middleware = [];
+        }
+
+        // For versions greater than 4.3.1 until 4.6.0, the middleware config did not include FlushEvents,
+        // but we always want to flush events at the end of the request, regardless of the config.
+        if (!in_array(Middleware\FlushEvents::class, $middleware)) {
+            $middleware[] = Middleware\FlushEvents::class;
+        }
+
+        return $middleware;
     }
 }

--- a/src/HoneybadgerServiceProvider.php
+++ b/src/HoneybadgerServiceProvider.php
@@ -264,7 +264,7 @@ class HoneybadgerServiceProvider extends ServiceProvider
         foreach ($middleware as $class) {
             if ($class === Middleware\FlushEvents::class) {
                 // We prefer to append FlushEvents middleware at the bottom of the stack.
-                // Hopefully it the terminate method will be called after all other middleware.
+                // Hopefully the terminate method will be called after all other middleware.
                 $kernel->pushMiddleware($class);
             }
             else {

--- a/src/Middleware/FlushEvents.php
+++ b/src/Middleware/FlushEvents.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Honeybadger\HoneybadgerLaravel\Middleware;
+
+use Honeybadger\HoneybadgerLaravel\Facades\Honeybadger;
+use Symfony\Component\HttpFoundation\Response;
+
+class FlushEvents
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+
+    /**
+     * Handle tasks after the response has been sent to the browser.
+     */
+    public function terminate(Request $request, Response $response): void
+    {
+        Honeybadger::flushEvents();
+    }
+}

--- a/src/Middleware/FlushEvents.php
+++ b/src/Middleware/FlushEvents.php
@@ -20,7 +20,7 @@ class FlushEvents
     /**
      * Handle tasks after the response has been sent to the browser.
      */
-    public function terminate(Request $request, Response $response): void
+    public function terminate(\Illuminate\Http\Request $request, \Illuminate\Http\Response $response): void
     {
         Honeybadger::flushEvents();
     }

--- a/src/Middleware/FlushEvents.php
+++ b/src/Middleware/FlushEvents.php
@@ -10,9 +10,8 @@ class FlushEvents
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle($request, $next): Response
     {
         return $next($request);
     }
@@ -20,7 +19,7 @@ class FlushEvents
     /**
      * Handle tasks after the response has been sent to the browser.
      */
-    public function terminate(\Illuminate\Http\Request $request, \Illuminate\Http\Response $response): void
+    public function terminate($request, $response): void
     {
         Honeybadger::flushEvents();
     }

--- a/tests/HoneybadgerServiceProviderTest.php
+++ b/tests/HoneybadgerServiceProviderTest.php
@@ -60,6 +60,7 @@ class HoneybadgerServiceProviderTest extends TestCase
     public function it_registers_only_flush_events_middleware_when_disabled()
     {
         $this->app['config']->set('honeybadger.middleware', []);
+        $this->app['config']->set('honeybadger.events.enabled', true);
         $this->partialMock(Kernel::class, function ($mock) {
             $mock->shouldReceive('prependMiddleware')
                 ->with(AssignRequestId::class)

--- a/tests/HoneybadgerServiceProviderTest.php
+++ b/tests/HoneybadgerServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Honeybadger\Tests;
 
 use Honeybadger\HoneybadgerLaravel\HoneybadgerServiceProvider;
 use Honeybadger\HoneybadgerLaravel\Middleware\AssignRequestId;
+use Honeybadger\HoneybadgerLaravel\Middleware\FlushEvents;
 use Honeybadger\LogEventHandler;
 use Honeybadger\LogHandler;
 use Honeybadger\Honeybadger;
@@ -46,19 +47,28 @@ class HoneybadgerServiceProviderTest extends TestCase
             $mock->shouldReceive('prependMiddleware')
                 ->with(AssignRequestId::class)
                 ->once();
+
+            $mock->shouldReceive('pushMiddleware')
+                ->with(FlushEvents::class)
+                ->once();
         });
         $provider = new HoneybadgerServiceProvider($this->app);
         $provider->boot();
     }
 
     /** @test */
-    public function it_does_not_register_middleware_when_disabled()
+    public function it_registers_only_flush_events_middleware_when_disabled()
     {
         $this->app['config']->set('honeybadger.middleware', []);
         $this->partialMock(Kernel::class, function ($mock) {
             $mock->shouldReceive('prependMiddleware')
                 ->with(AssignRequestId::class)
                 ->never();
+
+            // flush events middleware is always registered
+            $mock->shouldReceive('pushMiddleware')
+                ->with(FlushEvents::class)
+                ->once();
         });
         $provider = new HoneybadgerServiceProvider($this->app);
         $provider->boot();


### PR DESCRIPTION
## Status
**READY**

## Description
Adds a terminable middleware for flushing the events queue after the response is sent.

## Todo
- [x] Register FlushEvents middleware only if "events" are enabled
- [x] Register shutdown handler if app is running in a queue/worker
- [x] Update composer.json after this [PR](https://github.com/honeybadger-io/honeybadger-php/pull/229) is merged and released.
- [ ] Update documentation