### PR TITLE
fix: update success message sign-off to 'The Honeybadger Crew'

### DIFF
--- a/src/Commands/SuccessMessage.php
+++ b/src/Commands/SuccessMessage.php
@@ -32,7 +32,7 @@ love: making developers awesome.
 Happy 'badgering!
 
 Sincerely,
-Ben, Josh and Starr
+The Honeybadger Crew
 https://www.honeybadger.io/about/
 ⚡ --- End --------------------------------------------------------------------
 

--- a/tests/Commands/SuccessMessageTest.php
+++ b/tests/Commands/SuccessMessageTest.php
@@ -29,7 +29,7 @@ love: making developers awesome.
 Happy 'badgering!
 
 Sincerely,
-Ben, Josh and Starr
+The Honeybadger Crew
 https://www.honeybadger.io/about/
 ⚡ --- End --------------------------------------------------------------------
 


### PR DESCRIPTION
This is what we use in the Ruby gem:

https://github.com/honeybadger-io/honeybadger-ruby/blob/d6dc17fc15be465eea53fa4e149552260217d2e5/lib/honeybadger/cli/test.rb#L282-L286