### PR TITLE
fix: ensure correct instance order for Honeybadger mock test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,8 +55,6 @@ jobs:
       - name: Install Laravel ${{ matrix.laravel }}
         run: |
           if [ "${{ matrix.laravel }}" == "dev-master" ]; then
-        # temporary fix because the latest version of testbench does not accept dev-master for laravel/framework.
-        # previous versions of testbench throw error
             composer require "laravel/framework:^13.0.x-dev" "orchestra/testbench:^11.1@dev" "phpunit/phpunit:^13.1.0" --with-all-dependencies --no-interaction
           else
             composer require "laravel/framework:${{ matrix.laravel }}" --with-all-dependencies --no-interaction

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Install Laravel ${{ matrix.laravel }}
         run: |
           if [ "${{ matrix.laravel }}" == "dev-master" ]; then
-            composer require "laravel/framework:dev-master" "orchestra/testbench:^11.0@dev" "phpunit/phpunit:^12.5.8" --with-all-dependencies --no-interaction
+        # temporary fix because the latest version of testbench does not accept dev-master for laravel/framework.
+        # previous versions of testbench throw error
+            composer require "laravel/framework:^13.0.x-dev" "orchestra/testbench:^11.1@dev" "phpunit/phpunit:^13.1.0" --with-all-dependencies --no-interaction
           else
             composer require "laravel/framework:${{ matrix.laravel }}" --with-all-dependencies --no-interaction
           fi

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^9.2|^10.0|^11.0",
-        "phpunit/phpunit": "^10.5|^11.0"
+        "phpunit/phpunit": "^10.5|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AutomaticBreadcrumbsTest.php
+++ b/tests/AutomaticBreadcrumbsTest.php
@@ -261,11 +261,15 @@ class AutomaticBreadcrumbsTest extends TestCase
                         'connectionName' => 'database',
                         'queue' => null,
                         'job' => 'Illuminate\Queue\CallQueuedClosure',
+                        'id' => 1,
+                        'delay' => null,
                     ], $metadata),
                     2 => $this->assertEquals([
                         'connectionName' => 'database',
                         'queue' => null,
                         'job' => TestJob::class,
+                        'id' => 2,
+                        'delay' => null,
                     ], $metadata)
                 };
             });

--- a/tests/AutomaticBreadcrumbsTest.php
+++ b/tests/AutomaticBreadcrumbsTest.php
@@ -246,10 +246,13 @@ class AutomaticBreadcrumbsTest extends TestCase
 
         Config::set('honeybadger.breadcrumbs.automatic', [JobQueued::class]);
         Config::set('queue.default', 'database');
+
+        $honeybadger = $this->createMock(Reporter::class);
+        $this->app->instance(Reporter::class, $honeybadger);
+
         $this->loadMigrationsFrom(__DIR__.'/Fixtures/migrations');
 
         $matcher = $this->exactly(2);
-        $honeybadger = $this->createMock(Reporter::class);
         $honeybadger->expects($matcher)
             ->method('addBreadcrumb')
             ->willReturnCallback(function ($message, $metadata, $category) use ($matcher) {
@@ -266,7 +269,7 @@ class AutomaticBreadcrumbsTest extends TestCase
                     ], $metadata)
                 };
             });
-        $this->app->instance(Reporter::class, $honeybadger);
+
 
         dispatch(function () {
             // nothing doin'


### PR DESCRIPTION
## Status
**READY**

## Description
1. Setting events.enabled = true by default causes the Honeybadger singleton to be instantiated before getting replaced in the test code. When replaced by a mock instance in the test, the facade still has access to the un-mocked singleton, therefore assertions are failing. The fix was to re-order the registration of the mock before the facade is called.
2. Laravel latest version (dev-master) is not compatible with orchestra/testbench v11.0. Attempting to install v11.1 fails. Workaround is to temporarily switch to Laravel 13.0.x-dev (which is an alias of dev-master). Unfortunately there is no option in composer to force installation ignoring dependency requirements.
